### PR TITLE
Ensure /vendor directory exists

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ sqlite-local.db-wal
 
 # Ignore drupal core (if not versioning drupal sources)
 /vendor/*
+!/vendor/.keep
 LICENSE.txt
 .eslintignore
 .gitattributes


### PR DESCRIPTION
Changes proposed in this pull request:
- adds `/vendor/.keep` to ensure the vendor directory exists on a fresh clone.

Without this change, the initial `docker compose build` command found in `README.md` results in this error:

```
 => ERROR [usagov-2021_cms 10/13] COPY --chown=nginx:nginx vendor /var/www/vendor                                                                                                                                                                                            0.0s
------
 > [usagov-2021_cms 10/13] COPY --chown=nginx:nginx vendor /var/www/vendor:
------
failed to solve: rpc error: code = Unknown desc = failed to compute cache key: "/vendor" not found: not found
```
