### PR TITLE
htmltidy-helptext: Update helptext for copy/paste from Google Docs

### DIFF
--- a/config/sync/field.field.node.basic_page.body.yml
+++ b/config/sync/field.field.node.basic_page.body.yml
@@ -12,7 +12,7 @@ field_name: body
 entity_type: node
 bundle: basic_page
 label: Body
-description: "Steps to paste from Google Docs\r\n<ol>\r\n<li>Copy content from Google Doc</li>\r\n<li>Paste into <a href=\"https://www.gdoctohtml.com/\">gdoctohtml.com</a></li>\r\n<li>Click \"Tools\" > \"Source Code\"</li>\r\n<li>Remove all: <b><code>target=\"_blank\" rel=\"noopener”</code></b></li>\r\n<li>Copy the edited source code</li>\r\n<li>Paste into CKEditor</li>\r\n</ol>\r\n\r\n<i>*If there are no links in the content, you may skip steps 3-5</i>"
+description: "Steps to paste from Google Docs\r\n<ol>\r\n<li>Copy content from Google Doc</li>\r\n<li>Go to <a href=\"https://htmltidy.net/\">HTML Tidy</a></li>\r\n<li>Paste the content into the left side of HTML Tidy</li>\r\n<li>Click the \"Tidy\" button above the right side</li>\r\n<li>Copy the code from the right side of HTML Tidy</li>\r\n<li>In the WYSIWYG editor above, enter source mode by clicking the \"Source\" button</li>\r\n<li>Paste the code copied from HTML Tidy</li>\r\n<li>Return to WYSIWYG mode by clicking the \"Source\" button again</li>\r\n<li>Finish any other steps needed before publishing the page</li>\r\n</ol>"
 required: false
 translatable: true
 default_value: {  }


### PR DESCRIPTION
Fixes issue(s) # .

Changes proposed in this pull request:
-
-
-
