### PR TITLE
USAGOV-130-Language-Toggle-Override

### DIFF
--- a/config/sync/core.entity_form_display.node.basic_page.default.yml
+++ b/config/sync/core.entity_form_display.node.basic_page.default.yml
@@ -9,6 +9,7 @@ dependencies:
     - field.field.node.basic_page.field_for_contact_center_only
     - field.field.node.basic_page.field_header_html
     - field.field.node.basic_page.field_is_navigation_page
+    - field.field.node.basic_page.field_language_switcher_override
     - field.field.node.basic_page.field_page_intro
     - field.field.node.basic_page.field_page_type
     - node.type.basic_page
@@ -76,6 +77,14 @@ content:
     region: content
     settings:
       display_label: true
+    third_party_settings: {  }
+  field_language_switcher_override:
+    type: string_textfield
+    weight: 30
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
     third_party_settings: {  }
   field_page_intro:
     type: string_textarea

--- a/config/sync/core.entity_view_display.node.basic_page.default.yml
+++ b/config/sync/core.entity_view_display.node.basic_page.default.yml
@@ -47,14 +47,6 @@ content:
     third_party_settings: {  }
     weight: 4
     region: content
-  field_language_switcher_override:
-    type: string
-    label: above
-    settings:
-      link_to_entity: false
-    third_party_settings: {  }
-    weight: 7
-    region: content
   field_page_intro:
     type: basic_string
     label: hidden
@@ -71,5 +63,6 @@ hidden:
   field_css_icon: true
   field_for_contact_center_only: true
   field_is_navigation_page: true
+  field_language_switcher_override: true
   field_page_type: true
   langcode: true

--- a/config/sync/core.entity_view_display.node.basic_page.default.yml
+++ b/config/sync/core.entity_view_display.node.basic_page.default.yml
@@ -9,6 +9,7 @@ dependencies:
     - field.field.node.basic_page.field_for_contact_center_only
     - field.field.node.basic_page.field_header_html
     - field.field.node.basic_page.field_is_navigation_page
+    - field.field.node.basic_page.field_language_switcher_override
     - field.field.node.basic_page.field_page_intro
     - field.field.node.basic_page.field_page_type
     - node.type.basic_page
@@ -45,6 +46,14 @@ content:
     settings: {  }
     third_party_settings: {  }
     weight: 4
+    region: content
+  field_language_switcher_override:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 7
     region: content
   field_page_intro:
     type: basic_string

--- a/config/sync/core.entity_view_display.node.basic_page.teaser.yml
+++ b/config/sync/core.entity_view_display.node.basic_page.teaser.yml
@@ -10,6 +10,7 @@ dependencies:
     - field.field.node.basic_page.field_for_contact_center_only
     - field.field.node.basic_page.field_header_html
     - field.field.node.basic_page.field_is_navigation_page
+    - field.field.node.basic_page.field_language_switcher_override
     - field.field.node.basic_page.field_page_intro
     - field.field.node.basic_page.field_page_type
     - node.type.basic_page
@@ -45,6 +46,7 @@ hidden:
   field_for_contact_center_only: true
   field_header_html: true
   field_is_navigation_page: true
+  field_language_switcher_override: true
   field_page_intro: true
   field_page_type: true
   langcode: true

--- a/config/sync/field.field.node.basic_page.field_language_switcher_override.yml
+++ b/config/sync/field.field.node.basic_page.field_language_switcher_override.yml
@@ -1,0 +1,19 @@
+uuid: 827546e1-a127-4f24-a1b1-6c2b22a15a8e
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_language_switcher_override
+    - node.type.basic_page
+id: node.basic_page.field_language_switcher_override
+field_name: field_language_switcher_override
+entity_type: node
+bundle: basic_page
+label: 'Language Toggle Override'
+description: 'Overrides the link used for the language toggle. Useful for pages that do not have a direct match.'
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/field.storage.node.field_language_switcher_override.yml
+++ b/config/sync/field.storage.node.field_language_switcher_override.yml
@@ -1,0 +1,25 @@
+uuid: 5dde6fe1-f112-462e-9e43-fd8004ae3909
+langcode: en
+status: true
+dependencies:
+  module:
+    - field_permissions
+    - node
+third_party_settings:
+  field_permissions:
+    permission_type: public
+id: node.field_language_switcher_override
+field_name: field_language_switcher_override
+entity_type: node
+type: string
+settings:
+  max_length: 255
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/web/themes/custom/usagov/templates/block--languageswitcher.html.twig
+++ b/web/themes/custom/usagov/templates/block--languageswitcher.html.twig
@@ -1,0 +1,57 @@
+{#
+/**
+ * @file
+ * Theme override to display a block.
+ *
+ * Available variables:
+ * - plugin_id: The ID of the block implementation.
+ * - label: The configured label of the block if visible.
+ * - configuration: A list of the block's configuration values.
+ *   - label: The configured label for the block.
+ *   - label_display: The display settings for the label.
+ *   - provider: The module or other provider that provided this block plugin.
+ *   - Block plugin specific settings will also be stored here.
+ * - content: The content of this block.
+ * - attributes: array of HTML attributes populated by modules, intended to
+ *   be added to the main container tag of this template.
+ *   - id: A valid HTML ID and guaranteed unique.
+ * - title_attributes: Same as attributes, except applied to the main title
+ *   tag that appears in the template.
+ * - title_prefix: Additional output populated by modules, intended to be
+ *   displayed in front of the main title tag that appears in the template.
+ * - title_suffix: Additional output populated by modules, intended to be
+ *   displayed after the main title tag that appears in the template.
+ *
+ * @see template_preprocess_block()
+ */
+#}
+{%
+  set classes = [
+    'block',
+    'block-' ~ configuration.provider|clean_class,
+    'block-' ~ plugin_id|clean_class,
+  ]
+%}
+<div{{ attributes.addClass(classes) }}>
+  {{ title_prefix }}
+  {% if label %}
+    <h2{{ title_attributes }}>{{ label }}</h2>
+  {% endif %}
+  {{ title_suffix }}
+  {% block content %}
+    {# language_switcher_override allows content editors to manually specify a url for the language toggle #}
+    {% set language_switcher_override = node.field_language_switcher_override[0].value %}
+    {% if language_switcher_override %}
+      {% set lang = node.langcode[0].value %}
+      <ul class="links usa-nav__primary usa-accordion">
+        <li hreflang="{{ lang == 'es' ? 'en' : 'es' }}" class="usa-nav__primary-item">
+          <a href="{{language_switcher_override}}" class="language-link" hreflang="{{ lang == 'es' ? 'en' : 'es' }}">{{ lang == 'es' ? 'English' : 'Español' }}</a>
+        </li>
+      </ul>
+    {% else %}
+      {# if language_switcher_override is not set, then the default language_switcher content is used #}
+      {{ content }}
+    {% endif %}
+
+  {% endblock %}
+</div>


### PR DESCRIPTION
Fixes issue(s) # USAGOV-130.

Changes proposed in this pull request:
- Add a field that overrides the language toggle so content editors can manually set the url of the language toggle.
