### PR TITLE
usagov-92-share-this-page-exclusions

### DIFF
--- a/config/sync/block.block.englishsharethispage.yml
+++ b/config/sync/block.block.englishsharethispage.yml
@@ -43,4 +43,4 @@ visibility:
   request_path:
     id: request_path
     negate: true
-    pages: '<front>'
+    pages: "<front>\r\n/about-the-us-and-its-government\r\n/money-and-credit\r\n/laws-and-legal-issues\r\n/scams-and-frauds"

--- a/config/sync/block.block.spanishsharethispage.yml
+++ b/config/sync/block.block.spanishsharethispage.yml
@@ -43,4 +43,4 @@ visibility:
   request_path:
     id: request_path
     negate: true
-    pages: '<front>'
+    pages: "<front>\r\n/acerca-de-estados-unidos-y-directorios-del-gobierno\r\n/dinero-y-credito\r\n/leyes-y-asuntos-legales\r\n/estafas-y-fraudes"


### PR DESCRIPTION
Exclude sharethispage block from top-level nav pages

Fixes issue(s) # usagov-92.
