### PR TITLE
USAGOV-458-deploy-waf-by-tag: make deploy-waf accept two parameters '…

### DIFF
--- a/bin/cloudgov/deploy-waf
+++ b/bin/cloudgov/deploy-waf
@@ -13,7 +13,12 @@ fi
 
 DOCKERUSER=${DOCKERUSER:-dnark}
 DOCKERREPO=${DOCKERREPO:-usagov-2021}
-CONTAINERTAG=${1:-latest}
+CTAG=${1:-latest}
+CDIGEST=${2:-}
+
+# The Image digest for this tag should be looked up from cloud.gov storage
+# Any tag with a stored Image digest should be referenced by hash instead of tag
+
 
 # Need to create 'external-domain' service for custom routes: *.usa.gov
 # cf create-service external-domain domain stage-usagov-domain -c '{"domains": "cms-stage.usa.gov,beta-stage.usa.gov"}'
@@ -58,7 +63,19 @@ printf "\tAPPS_DOMAIN: $ROUTE_DOMAIN\n"
 cf set-env waf http_proxy  ""
 cf set-env waf https_proxy ""
 
-cf push "${ROUTE_SERVICE_APP_NAME}" --no-start --var app-name="${ROUTE_SERVICE_APP_NAME}"
+# launch the app
+if [ -z "$CDIGEST" ]; then
+  echo "Deploying ${DOCKERUSER}/${DOCKERREPO}:waf-${CTAG}"
+  cf push "${ROUTE_SERVICE_APP_NAME}" --no-start \
+    --var app-name="${ROUTE_SERVICE_APP_NAME}" \
+    --docker-image ${DOCKERUSER}/${DOCKERREPO}:waf-${CTAG}
+else
+  echo "Deploying ${DOCKERUSER}/${DOCKERREPO} waf-${CTAG} via digest ${CDIGEST}"
+  cf push "${ROUTE_SERVICE_APP_NAME}" --no-start \
+    --var app-name="${ROUTE_SERVICE_APP_NAME}" \
+    --docker-image ${DOCKERUSER}/${DOCKERREPO}${CDIGEST}
+fi
+
 cf set-env "${ROUTE_SERVICE_APP_NAME}" ALLOWED_IPS "$(printf "%s" "${NGINX_ALLOW_STATEMENTS:-}")"
 cf start "${ROUTE_SERVICE_APP_NAME}"
 


### PR DESCRIPTION
…ctag' and 'digest' in the same way as deploy-cms

<!--- Provide a general summary of your changes in the title above -->
## Jira Task
<!--- Provide a link to the Jira ticket -->
https://cm-jira.usa.gov/browse/USAGOV-458

## Description
<!--- Describe your changes in detail -->
update waf deploy script to follow the same rules as cms deploy

## Checklist for the Developer
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [ ] A link to the JIRA ticket has been added above.
- [ ] The JIRA ticket identifies the desired result of this change.
- [ ] The JIRA ticket contains clear acceptance criteria.
- [ ] The JIRA ticket contains clear testing steps.
- [ ] The JIRA ticket contains a description of "Done".
- [ ] Any preparation/installation/update steps required for this code to work properly (drush commands, scripts, configuration updates) are documented in the ticket.

## Checklist for the Peer Reviewers
- [ ] The branch name of this PR matches the project standards.
- [ ] QA steps are followed and any changes to process are updated in the ticket.
- [ ] Code Standards are followed, there are no bad practices in use.
- [ ] Config changes (if any) include only necessary changes.
- [ ] No errors in Drupal or Client Browser.
- [ ] Code has been tested locally (if possible).
- [ ] Following AC and Testing Steps verify changes work as expected.
- [ ] There are no known side-effects outside of expected behavior.
