### PR TITLE
Usagov 209 target h1s

### DIFF
--- a/web/themes/custom/usagov/scripts/lookup.js
+++ b/web/themes/custom/usagov/scripts/lookup.js
@@ -271,7 +271,7 @@ function renderResults(response, rawResponse) {
                 linkToContact.innerHTML = content["contact-via-email"];
 
                 linkToContact.setAttribute("href", content["path-contact"] + "?email=" + emailLinkified +
-                    "?name=" + response.officials[i].name + "?office=" + response.officials[i].office);
+                    "?name=" + response.officials[i].name + "?office=" + response.officials[i].office) + "#skip-to-h1";
                 // linkToContact.appendChild(primaryEmail);
 
                 bulletList.appendChild(linkToContact);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
## Jira Task
<!--- Provide a link to the Jira ticket -->
https://cm-jira.usa.gov/browse/USAGOV-209

## Description
<!--- Describe your changes in detail -->
Another one-liner. When a user in the Contact Elected Officials flow clicks the email button to navigate to the email composition form, we want to target the H1 of the resulting page, not the top. To do this, I'm adding #skip-to-h1 to the form action. 

It's also necessary to remove "autofocus" from the first textarea on the form on the email page, which is in the page body, if that hasn't already been done.

## Checklist for the Developer
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [x] A link to the JIRA ticket has been added above.
- [x] The JIRA ticket identifies the desired result of this change.
- [ ] The JIRA ticket contains clear acceptance criteria.
- [ ] The JIRA ticket contains clear testing steps.
- [ ] The JIRA ticket contains a description of "Done".
- [x] Any preparation/installation/update steps required for this code to work properly (drush commands, scripts, configuration updates) are documented in the ticket.

## Checklist for the Peer Reviewers
- [x] The branch name of this PR matches the project standards.
- [ ] QA steps are followed and any changes to process are updated in the ticket.
- [ ] Code Standards are followed, there are no bad practices in use.
- [ ] Config changes (if any) include only necessary changes.
- [ ] No errors in Drupal or Client Browser.
- [ ] Code has been tested locally (if possible).
- [ ] Following AC and Testing Steps verify changes work as expected.
- [ ] There are no known side-effects outside of expected behavior.
