### PR TITLE
USAGOV-487-coe-remove-uri-target-from-text: COE lookup: remove hash f…

### DIFF
--- a/web/themes/custom/usagov/scripts/lookup.js
+++ b/web/themes/custom/usagov/scripts/lookup.js
@@ -8,7 +8,7 @@ function lookup(address, callback) {
      * Request object for given parameters.
      * @type {gapi.client.HttpRequest}
      */
-    
+
     let count=0;
     var timer = window.setInterval(function(){
         count++;
@@ -24,7 +24,7 @@ function lookup(address, callback) {
             window.clearInterval(timer);
         }
     }, 100);
-    
+
 }
 
 /**
@@ -219,7 +219,7 @@ function renderResults(response, rawResponse) {
                 for (let j = 0; j < socials.length; j++) {
                     // Create appropriate type of link
                     // for each social media account
-                    
+
 
                     // let linkToSocial = document.createElement("a");
                     // let socialURL = ``;
@@ -272,7 +272,6 @@ function renderResults(response, rawResponse) {
 
                 linkToContact.setAttribute("href", content["path-contact"] + "?email=" + emailLinkified +
                     "?name=" + response.officials[i].name + "?office=" + response.officials[i].office) + "#skip-to-h1";
-                // linkToContact.appendChild(primaryEmail);
 
                 bulletList.appendChild(linkToContact);
             }
@@ -315,10 +314,11 @@ function renderResults(response, rawResponse) {
  * Process form data, display the address, and search for elected officials.
  */
 function load() {
-    let inputStreet = window.location.href.split("input-street=")[1].split("&")[0].split("+").join(" ");
-    let inputCity = window.location.href.split("input-city=")[1].split("&")[0].split("+").join(" ");
-    let inputState = window.location.href.split("input-state=")[1].split("&")[0];
-    let inputZip = window.location.href.split("input-zip=")[1].split("&")[0];
+    let hrefWithoutHash = window.location.href.replace(window.location.hash, "");
+    let inputStreet = hrefWithoutHash.split("input-street=")[1].split("&")[0].split("+").join(" ");
+    let inputCity = hrefWithoutHash.split("input-city=")[1].split("&")[0].split("+").join(" ");
+    let inputState = hrefWithoutHash.split("input-state=")[1].split("&")[0];
+    let inputZip = hrefWithoutHash.split("input-zip=")[1].split("&")[0];
 
     let normalizedAddress = inputStreet + ", " + inputCity + ", " + inputState + " " + inputZip;
 


### PR DESCRIPTION
…rom location.href before parsing address from query params.

<!--- Provide a general summary of your changes in the title above -->
## Jira Task
<!--- Provide a link to the Jira ticket -->
https://cm-jira.usa.gov/browse/USAGOV-487

## Description
<!--- Describe your changes in detail -->
Recently, I added a hash (#skip-to-h1) to the URLs in the Contact Elected Officials app, so that when a user navigated from one page to the next, focus would jump to the page heading. On the "step 2" page where the user's street address is displayed, "#skip-to-h1" was being appended to an address field. This change removes the hash from the string before parsing out the address parts so it doesn't appear in the page content. 

This is in client-side javascript, so at most you might need to refresh the page in your browser to get the latest lookup.js code to load. 

## Checklist for the Developer
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [x] A link to the JIRA ticket has been added above.
- [x] The JIRA ticket identifies the desired result of this change.
- [x] The JIRA ticket contains clear acceptance criteria.
- [ ] The JIRA ticket contains clear testing steps.
- [ ] The JIRA ticket contains a description of "Done".
- [ ] Any preparation/installation/update steps required for this code to work properly (drush commands, scripts, configuration updates) are documented in the ticket.

## Checklist for the Peer Reviewers
- [x] The branch name of this PR matches the project standards.
- [x] QA steps are followed and any changes to process are updated in the ticket.
- [x] Code Standards are followed, there are no bad practices in use.
- [ ] Config changes (if any) include only necessary changes.
- [x] No errors in Drupal or Client Browser.
- [x] Code has been tested locally (if possible).
- [ ] Following AC and Testing Steps verify changes work as expected.
- [x] There are no known side-effects outside of expected behavior.
