### PR TITLE
USAGOV-558: COE error messages

### DIFF
--- a/web/themes/custom/usagov/html-blocks/contact-elected-officials-spanish.html
+++ b/web/themes/custom/usagov/html-blocks/contact-elected-officials-spanish.html
@@ -1,5 +1,5 @@
 <div class="usa-prose">
-    
+
 
     <div class="usa-prose">
         <h2>
@@ -33,9 +33,9 @@
                 <a href="#input-state"><span>Por favor, escriba el nombre del estado.</span></a>
             </li>
             <li  id="error-zip" class="usa-alert__text">
-                <a href="#input-zip"><span>Por favor, escriba código postal.</span></a>
-            </li> 
-        </ul> 
+                <a href="#input-zip"><span>Por favor, escriba el código postal.</span></a>
+            </li>
+        </ul>
     </div>
 </div>
         <form class="usa-form maxw-none" action="/es/funcionarios-electos" autocomplete="off" name="myform" id="myform" novalidate onsubmit="return myforms(event);">
@@ -149,7 +149,7 @@
 <button class="usa-button usa-button--secondary usa-button--big">Encontrar a mis funcionarios electos</button>
                 </div>
             </div>
-            
+
         </form>
     </div>
 </div>

--- a/web/themes/custom/usagov/scripts/accessibility.js
+++ b/web/themes/custom/usagov/scripts/accessibility.js
@@ -40,7 +40,17 @@ function myforms(event) {
                 test.push(error + " missing");
                 elmnts[k].classList.add("usa-user-error");
                 elmnts[k].previousElementSibling.classList.add("usa-error");
-                let message = a11y_content[error];
+                
+		// Changing to use the error method specified in the CMS if available
+        	var errorID = "error-" + error;
+        	var cmsError = document.getElementById(errorID);
+        	if(cmsError){
+          		var message = cmsError.getElementsByTagName("span")[0].innerHTML;
+
+        	}else {
+          		var message = a11y_content[error];
+        	}
+
                 elmnts[k].previousElementSibling.innerHTML = message;
                 event.preventDefault();
                 errorFound = true;  
@@ -120,7 +130,19 @@ function myforms(event) {
     
     if (errorFound) {
         document.getElementById("error-box").focus();
+	if (test.length == 1) {
+      	  if (document.documentElement.lang == "en") {
+            document.getElementById("error-box").getElementsByTagName("h3")[0].innerHTML = "Your information contains an error";
+	  } else {
+	    document.getElementById("error-box").getElementsByTagName("h3")[0].innerHTML = "Su información contiene 1 error";
+	  }
+    	} else {
+	  if (document.documentElement.lang == "en") {
 	    document.getElementById("error-box").getElementsByTagName("h3")[0].innerHTML = "Your information contains " + test.length + " errors";
+	  } else {
+	    document.getElementById("error-box").getElementsByTagName("h3")[0].innerHTML = "Su información contiene " + test.length + " errores";
+      	  }
+    	}
         dataLayer.push({'event':'CEO form error','error type':test.join(";")});
         return false
     }

--- a/web/themes/custom/usagov/scripts/accessibility.js
+++ b/web/themes/custom/usagov/scripts/accessibility.js
@@ -1,5 +1,8 @@
 /**
  * Improve the accessibility of pages with input fields.
+ * Creating error messages so users know which fields need attention. Error messages are managed on CMS in the body element and element ID's are used to get the respective text.
+ * Used on pages: find and contact elected officials; email your elected official
+ * a11y_translations is used as fallback for pages where error message is not included in the CMS.
  */
 
 const a11y_translations = {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
## Jira Task
<!--- Provide a link to the Jira ticket -->
https://cm-jira.usa.gov/browse/USAGOV-557

## Description
<!--- Describe your changes in detail -->
When submitting the form on http://localhost/elected-officials if only one error exists the error message should read in the singular. Essentially for this I just made a length check on the error array we create, and print out a different sentence in English and Spanish for a singular error. 

While looking into this  @akf also asked me to look at the error messages and moving them into the CMS. I found that we have two error messages printing on the screen, one populated from the CMS and the other from the JS. The code now does a check to see if the error messages are present in the DOM from the CMS and if so it uses that. Since the script we are using is used on multiple pages I also keep the error message array created in the script and use that if the error messages are not already included in the DOM. I just wanted to note this since its used on multiple pages. 

Desired Result - Correct singular/plural wording for errors. 

Acceptance/Testing/Done - 
1. Fill in all but one field on the form. Make sure error reads "Your information contains an error" 
2. Leave multiple fields black. Make sure error reads "Your information contains " + num of errors + " errors"

I would appreciate someone verifying the correctness of the script overall. I only see that it is used on  find and contact elected officials; email your elected official and I believe I have tested for correctness but I would appreciate if anyone familiar could verify. 

## Checklist for the Developer
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [x] A link to the JIRA ticket has been added above.
- [x] The JIRA ticket identifies the desired result of this change.
- [x] The JIRA ticket contains clear acceptance criteria.
- [x] The JIRA ticket contains clear testing steps.
- [x] The JIRA ticket contains a description of "Done".
- [x] Any preparation/installation/update steps required for this code to work properly (drush commands, scripts, configuration updates) are documented in the ticket.

## Checklist for the Peer Reviewers
- [ ] The branch name of this PR matches the project standards.
- [ ] QA steps are followed and any changes to process are updated in the ticket.
- [ ] Code Standards are followed, there are no bad practices in use.
- [ ] Config changes (if any) include only necessary changes.
- [ ] No errors in Drupal or Client Browser.
- [ ] Code has been tested locally (if possible).
- [ ] Following AC and Testing Steps verify changes work as expected.
- [ ] There are no known side-effects outside of expected behavior.
