### PR TITLE
USAGOV-544: turn off modsecurity audit log

### DIFF
--- a/.docker/src-waf/etc/nginx/nginx.conf
+++ b/.docker/src-waf/etc/nginx/nginx.conf
@@ -5,6 +5,9 @@ worker_processes auto;
 
 pid /var/run/nginx.pid;
 
+# Configure default error logger.
+error_log /var/log/nginx/error.log warn;
+
 events {
     worker_connections ${WORKER_CONNECTIONS};
 }

--- a/.docker/src-waf/etc/nginx/snippets/owasp-modsecurity-main.conf
+++ b/.docker/src-waf/etc/nginx/snippets/owasp-modsecurity-main.conf
@@ -1,4 +1,5 @@
 # Include the recommended configuration
 Include /opt/owasp-crs/modsecurity.conf
+Include /opt/owasp-crs/modsecurity-override.conf
 # A test rule
 SecRule ARGS:testparam "@contains test" "id:1234,deny,log,status:403"

--- a/.docker/src-waf/opt/owasp-crs/modsecurity-override.conf
+++ b/.docker/src-waf/opt/owasp-crs/modsecurity-override.conf
@@ -8,8 +8,8 @@ SecAuditEngine Off
 #SecAuditLogType Serial
 #SecCookieFormat 0
 #SecDataDir /tmp/modsecurity/data
-SecDebugLog /dev/null 2>&1
-SecDebugLogLevel 3
+#SecDebugLog /var/log/modsecurity/debug.log
+#SecDebugLogLevel 3
 #SecPcreMatchLimit 100000
 #SecPcreMatchLimitRecursion 100000
 #SecRequestBodyAccess on


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
## Jira Task
<!--- Provide a link to the Jira ticket -->
https://cm-jira.usa.gov/browse/USAGOV-544

## Description
<!--- Describe your changes in detail -->
The audit log is a lot more than we want, and it was writing to a local file. The changes here turn it off. 

I've also added an explicit error_log directive for nginx, setting the log level to warn. My goal was to get the basic messages modsecurity usually emits to be logged by nginx. (I have been unsuccessful in proving that this works.) 

## Checklist for the Developer
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [x] A link to the JIRA ticket has been added above.
- [x] The JIRA ticket identifies the desired result of this change.
- [ ] The JIRA ticket contains clear acceptance criteria.
- [ ] The JIRA ticket contains clear testing steps.
- [ ] The JIRA ticket contains a description of "Done".
- [ ] Any preparation/installation/update steps required for this code to work properly (drush commands, scripts, configuration updates) are documented in the ticket.

## Checklist for the Peer Reviewers
- [ ] The branch name of this PR matches the project standards.
- [ ] QA steps are followed and any changes to process are updated in the ticket.
- [ ] Code Standards are followed, there are no bad practices in use.
- [ ] Config changes (if any) include only necessary changes.
- [ ] No errors in Drupal or Client Browser.
- [ ] Code has been tested locally (if possible).
- [ ] Following AC and Testing Steps verify changes work as expected.
- [ ] There are no known side-effects outside of expected behavior.
