### PR TITLE
USAGOV-496-set-cookie-secure: add Secure flag to Drupal session cookie

### DIFF
--- a/.docker/src-waf/etc/nginx/conf.d/default.conf
+++ b/.docker/src-waf/etc/nginx/conf.d/default.conf
@@ -21,6 +21,7 @@ server {
 
     location / {
         proxy_pass http://127.0.0.1:$port;
+        proxy_cookie_flags ~SESS.* secure;
     }
 }
 


### PR DESCRIPTION
Use nginx config on the WAF to set the Secure flag on the drupal session cookie.

<!--- Provide a general summary of your changes in the title above -->
## Jira Task
<!--- Provide a link to the Jira ticket -->
https://cm-jira.usa.gov/browse/USAGOV-496

## Description
<!--- Describe your changes in detail -->
Added a proxy_cookie_flags directive to the WAF's nginx config. The only thing remotely fancy here is that I'm using a regex to specify cookies with names that start with SESS. 

Having this on the WAF is nice because it only adds the Secure flag when the HTTPS is set up (that is, not local dev). 

I tested this line "live" on cms-stage.usa.gov, so I think the only thing to verify will be that it really gets into place where I expect when we deploy the waf. 

## Checklist for the Developer
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [x] A link to the JIRA ticket has been added above.
- [x] The JIRA ticket identifies the desired result of this change.
- [x] The JIRA ticket contains clear acceptance criteria.
- [x] The JIRA ticket contains clear testing steps.
- [x] The JIRA ticket contains a description of "Done".
- [ ] Any preparation/installation/update steps required for this code to work properly (drush commands, scripts, configuration updates) are documented in the ticket.

## Checklist for the Peer Reviewers
- [ ] The branch name of this PR matches the project standards.
- [ ] QA steps are followed and any changes to process are updated in the ticket.
- [ ] Code Standards are followed, there are no bad practices in use.
- [ ] Config changes (if any) include only necessary changes.
- [ ] No errors in Drupal or Client Browser.
- [ ] Code has been tested locally (if possible).
- [ ] Following AC and Testing Steps verify changes work as expected.
- [ ] There are no known side-effects outside of expected behavior.
