### PR TITLE
Usagov-455: Add language toggles from mothership export

### DIFF
--- a/web/modules/custom/usagov_directories/src/Form/DirectoryRecordsAddTogglesForm.php
+++ b/web/modules/custom/usagov_directories/src/Form/DirectoryRecordsAddTogglesForm.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Drupal\usagov_directories\Form;
+
+use Drupal\Core\Form\FormBase;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\node\Entity\Node;
+
+/**
+ * Implements a form an administrator can use to add language toggles to
+ * already-imported directory records.
+ * This is expected to be used during development and never again thereafter.
+ */
+class DirectoryRecordsAddTogglesForm extends FormBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'directory_records_add_toggles_form';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    // $form['attributes'] = ['enctype' => 'multipart/form-data'];
+    $form['description'] = [
+      '#type' => 'processed_text',
+      '#text' => $this->t('Submit this form to add or update the language toggles on records imported from Mothership.'),
+    ];
+    $form['toggle_map_file'] = [
+      '#type' => 'file',
+      '#upload_validators' => [
+        'file_validate_extensions' => ['csv'], // Does nothing for 'file'
+      ],
+      '#title' => $this->t('Upload a csv file of "mothership_uuid,toggle_mothership_uuid"'),
+      // '#required' => TRUE, // might work in 9.5? https://www.drupal.org/project/drupal/issues/59750
+    ];
+    $form['actions']['#type'] = 'actions';
+    $form['actions']['submit'] = [
+      '#type' => 'submit',
+      '#value' => $this->t('Add (or Update) Language Toggles'),
+      '#button_type' => 'primary',
+    ];
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function validateForm(array &$form, FormStateInterface $form_state) {
+    $all_files = $this->getRequest()->files->get('files', []);
+    $file = $all_files['toggle_map_file'];
+    if (isset($file)) {
+      $filestream = $file->openFile('r');
+      $toggle_map = [];
+      while (!$filestream->eof()) {
+        $toggle_map[] = $filestream->fgetcsv();
+      }
+      $form_state->set('toggle_map', $toggle_map);
+    }
+    else {
+      $form_state->setErrorByName('toggle_map_file', 'Please select a file to upload!');
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+  }
+
+}

--- a/web/modules/custom/usagov_directories/usagov_directories.routing.yml
+++ b/web/modules/custom/usagov_directories/usagov_directories.routing.yml
@@ -1,7 +1,14 @@
-usagov_directories.form:
+usagov_directories.delete_form:
   path: '/admin/usagov_directories/delete_records'
   defaults:
     _title: 'Delete Directory Records'
     _form: '\Drupal\usagov_directories\Form\DirectoryRecordsDeleteForm'
+  requirements:
+    _permission: 'administer site configuration'
+usagov_directories.add_toggles_form:
+  path: '/admin/usagov_directories/add_language_toggles'
+  defaults:
+    _title: 'Add Language Toggles'
+    _form: '\Drupal\usagov_directories\Form\DirectoryRecordsAddTogglesForm'
   requirements:
     _permission: 'administer site configuration'

--- a/web/modules/custom/usagov_directories/utility/make_toggle_map.php
+++ b/web/modules/custom/usagov_directories/utility/make_toggle_map.php
@@ -15,8 +15,8 @@
  * - akf, 2022-08-31
  */
 
-$infile = '/Users/amykfarrell/dev/data_to_import/mothership/directory-report.csv'; // $argv[1];
-$outfile = '/Users/amykfarrell/dev/data_to_import/mothership/toggle_map.csv'; // $argv[2];
+$infile = $argv[1];
+$outfile = $argv[2];
 
 function main($infile, $outfile) {
   $fp_infile = fopen($infile, 'r');


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
## Jira Task
<!--- Provide a link to the Jira ticket -->
https://cm-jira.usa.gov/browse/USAGOV-455

## Description
<!--- Describe your changes in detail -->
Adds a form at /admin/usagov_directories/add_language_toggles for upload of a CSV file of UUID mappings from mothership, with the UUIDs of mothership nodes and their language toggles, for example: 
 
  mothership_uuid,toggle_mothership_uuid
  9d2f6dcd-2ee0-439e-8af2-b1a2d0fe39a8,99cd98fd-1700-4920-a53d-c7ebb5956f30

Upon submission, the form looks nodes by field_mothership_uuid and sets the targets for the language toggle field appropriately. 


## To Test: 

This assumes that in a previous step, data was imported with field_mothership_uuid set. :-) 

1. Download https://drive.google.com/drive/folders/1xw33rd_TGSGA9ExF1QX2EOjnzFWMMEgx (toggle_map.csv)
2. Because this adds a new page, you will need to flush caches. 
3. Go to the page /admin/usagov_directories/add_language_toggles
4. Select toggle_map.csv as the file to upload, and submit the form. 
5. Spot-check the results: The easiest way is to go to Admin->Content and filter on "Federal Directory Record" and language. The pages that had toggles added will be listed first, as they will have just been updated. Open a few and confirm that the "English" and "Español" buttons appear and link to the correct pages. 

## Checklist for the Developer
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [x] A link to the JIRA ticket has been added above.
- [ ] The JIRA ticket identifies the desired result of this change.
- [ ] The JIRA ticket contains clear acceptance criteria.
- [ ] The JIRA ticket contains clear testing steps.
- [ ] The JIRA ticket contains a description of "Done".
- [x] Any preparation/installation/update steps required for this code to work properly (drush commands, scripts, configuration updates) are documented in the ticket.

## Checklist for the Peer Reviewers
- [ ] The branch name of this PR matches the project standards.
- [ ] QA steps are followed and any changes to process are updated in the ticket.
- [ ] Code Standards are followed, there are no bad practices in use.
- [ ] Config changes (if any) include only necessary changes.
- [ ] No errors in Drupal or Client Browser.
- [ ] Code has been tested locally (if possible).
- [ ] Following AC and Testing Steps verify changes work as expected.
- [ ] There are no known side-effects outside of expected behavior.
