### PR TITLE
Usagov 388 run tome after deploy

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -7,6 +7,10 @@ if [ -z "${VCAP_SERVICES:-}" ]; then
     exit 1;
 fi
 
+if [ ! -f /container_start_timestamp ]; then
+    echo "$(date +'%s')" > /container_start_timestamp;
+fi
+
 SECRETS=$(echo $VCAP_SERVICES | jq -r '.["user-provided"][] | select(.name == "secrets") | .credentials')
 SECAUTHSECRETS=$(echo $VCAP_SERVICES | jq -r '.["user-provided"][] | select(.name == "secauthsecrets") | .credentials')
 

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -8,7 +8,9 @@ if [ -z "${VCAP_SERVICES:-}" ]; then
 fi
 
 if [ ! -f /container_start_timestamp ]; then
-    echo "$(date +'%s')" > /container_start_timestamp;
+  touch /container_start_timestamp
+  chmod a+r /container_start_timestamp
+  echo "$(date +'%s')" > /container_start_timestamp
 fi
 
 SECRETS=$(echo $VCAP_SERVICES | jq -r '.["user-provided"][] | select(.name == "secrets") | .credentials')


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
## Jira Task
<!--- Provide a link to the Jira ticket -->
https://cm-jira.usa.gov/browse/USAGOV-388

## Description
<!--- Describe your changes in detail -->

This is an attempt to fix an edge case where tome should run immediately after a deploy. Original code tried to ask for system uptime, but was accidentally getting the system uptime of the host, this code adds a step to the bootstrapping process where a timestamp is stored in a file at container start time, and that timestamp is used to check uptime by tome.

## Checklist for the Developer
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [x] A link to the JIRA ticket has been added above.
- [x] The JIRA ticket identifies the desired result of this change.
- [x] The JIRA ticket contains clear acceptance criteria.
- [x] The JIRA ticket contains clear testing steps.
- [x] The JIRA ticket contains a description of "Done".
- [x] Any preparation/installation/update steps required for this code to work properly (drush commands, scripts, configuration updates) are documented in the ticket.

## Checklist for the Peer Reviewers
- [ ] The branch name of this PR matches the project standards.
- [ ] QA steps are followed and any changes to process are updated in the ticket.
- [ ] Code Standards are followed, there are no bad practices in use.
- [ ] Config changes (if any) include only necessary changes.
- [ ] No errors in Drupal or Client Browser.
- [ ] Code has been tested locally (if possible).
- [ ] Following AC and Testing Steps verify changes work as expected.
- [ ] There are no known side-effects outside of expected behavior.
