### PR TITLE
USAGOV-583: Correct syntax errors in tome_sync.sh that raised warnings and prevented restoring IFS setting after renaming files.

### DIFF
--- a/scripts/tome-sync.sh
+++ b/scripts/tome-sync.sh
@@ -96,18 +96,18 @@ done
 # lower case all filenames in the copied dir before uploading
 LCF=0
 echo "Lower-casing files:"
-old_IFS = "$IFS"
+old_IFS="$IFS"
 IFS=$'\n'
 for f in `find $RENDER_DIR/*`; do
   ff=$(echo $f | tr '[A-Z]' '[a-z]');
   if [ "$f" != "$ff" ]; then
     # VERBOSE MODE
-    # mv -v "$f" "$ff"
+    # mv -v "$f" "$fff"
     mv -v "$f" "$ff" > /dev/null
     LCF=$((LCF+1))
   fi
 done
-IFS = "$old_IFS"
+IFS="$old_IFS"
 echo "    $LCF"
 
 # get a count of current AWS files, total and by extension


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the title above -->
## Jira Task
<!--- Provide a link to the Jira ticket -->
https://cm-jira.usa.gov/browse/USAGOV-583

## Description
<!--- Describe your changes in detail -->
I was watching the cms logs on dev, as one does, and saw these warnings during a tome run: 

   2022-12-08T15:15:56.75-0800 [APP/PROC/WEB/0] OUT Lower-casing files:
   2022-12-08T15:15:56.75-0800 [APP/PROC/WEB/0] ERR /var/www/scripts/tome-sync.sh: line 99: old_IFS: not found
   2022-12-08T15:16:00.28-0800 [APP/PROC/WEB/0] ERR /var/www/scripts/tome-sync.sh: line 110: IFS: not found

Extraneous spaces around "=" were the cause. Fortunately this didn't break anything later in the script, but here's a fix. 


## Checklist for the Developer
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [x] A link to the JIRA ticket has been added above.
- [ ] The JIRA ticket identifies the desired result of this change.
- [ ] The JIRA ticket contains clear acceptance criteria.
- [ ] The JIRA ticket contains clear testing steps.
- [ ] The JIRA ticket contains a description of "Done".
- [ ] Any preparation/installation/update steps required for this code to work properly (drush commands, scripts, configuration updates) are documented in the ticket.

## Checklist for the Peer Reviewers
- [ ] The branch name of this PR matches the project standards.
- [ ] QA steps are followed and any changes to process are updated in the ticket.
- [ ] Code Standards are followed, there are no bad practices in use.
- [ ] Config changes (if any) include only necessary changes.
- [ ] No errors in Drupal or Client Browser.
- [ ] Code has been tested locally (if possible).
- [ ] Following AC and Testing Steps verify changes work as expected.
- [ ] There are no known side-effects outside of expected behavior.
