### PR TITLE
USAGOV-617-data-attributes-for-agency-accordions: Restore unique IDs …

### DIFF
--- a/web/themes/custom/usagov/templates/views-view-fields--federal-agencies.html.twig
+++ b/web/themes/custom/usagov/templates/views-view-fields--federal-agencies.html.twig
@@ -38,13 +38,13 @@
 
 {% set lang = row._entity.langcode.value %}
 {% set UTitle = 'dr-' ~ fields.title.content|striptags|trim %}
-{% set UID = 'dr-' ~ fields.nid.content|striptags|trim %}
+{% set UID = fields.nid.content|striptags|trim %}
 
 <div class="usa-accordion usagov-directory-accordion-container">
   <h2 class="usa-accordion__heading">
     <button
-      aria-controls="{{- UID -}}"
-      Utitle-id="{{- UTitle -}}"
+      aria-controls="{{- UTitle -}}"
+      data-node-id="{{- UID -}}"
       aria-expanded="false"
       class="usa-accordion__button"
       >
@@ -52,7 +52,7 @@
     </button>
   </h2>
 
-  <div class="usa-accordion__content usa-prose" id="{{- UID -}}" Utitle-id="{{- UTitle -}}">
+  <div class="usa-accordion__content usa-prose" id="{{- UTitle -}}" data-node-id="{{- UID -}}">
     <p>{{- fields.field_page_intro.content -}}</p>
 
     {% if fields.field_website.content|striptags|trim %}


### PR DESCRIPTION
…on the agency-index accordions; supply node ID as data-node-id.

<!--- Provide a general summary of your changes in the title above -->
## Jira Task
<!--- Provide a link to the Jira ticket -->
https://cm-jira.usa.gov/browse/USAGOV-617

## Description
<!--- Describe your changes in detail -->
For the listing at /agency-index, restores the use of the agency (or synonym) titles for element IDs, and relegates node IDs to data-node-id attributes. 

The accordions on /agency-index should "just work," and should work when a synonym is present on the same page as the agency's canonical name (or on the same page with another synonym for the same agency). 

## Checklist for the Developer
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [x] A link to the JIRA ticket has been added above.
- [ ] The JIRA ticket identifies the desired result of this change.
- [ ] The JIRA ticket contains clear acceptance criteria.
- [ ] The JIRA ticket contains clear testing steps.
- [ ] The JIRA ticket contains a description of "Done".
- [ ] Any preparation/installation/update steps required for this code to work properly (drush commands, scripts, configuration updates) are documented in the ticket.

## Checklist for the Peer Reviewers
- [ ] The branch name of this PR matches the project standards.
- [ ] QA steps are followed and any changes to process are updated in the ticket.
- [ ] Code Standards are followed, there are no bad practices in use.
- [ ] Config changes (if any) include only necessary changes.
- [ ] No errors in Drupal or Client Browser.
- [ ] Code has been tested locally (if possible).
- [ ] Following AC and Testing Steps verify changes work as expected.
- [ ] There are no known side-effects outside of expected behavior.
