### PR TITLE
USAGOV-387: Repair a broken sed pattern in scripts/tome-synch.sh

### DIFF
--- a/scripts/tome-sync.sh
+++ b/scripts/tome-sync.sh
@@ -82,7 +82,7 @@ do
   # Add attached buckets to the allow list
   REF_BUCKET=$(            echo -E "$VCAP_SERVICES" | jq -r ".s3[$i].credentials.bucket")
   REF_AWS_ENDPOINT=$(      echo -E "$VCAP_SERVICES" | jq -r ".s3[$i].credentials.endpoint" | uniq )
-  REF_AWS_ENDPOINT_ALT=$(  echo -E "$REF_AWS_ENDPOINT"  | sed '/s3\-us\-/s3.us-/' | uniq )
+  REF_AWS_ENDPOINT_ALT=$(  echo -E "$REF_AWS_ENDPOINT"  | sed 's/s3\-us\-/s3.us-/' | uniq )
   REF_AWS_FIPS_ENDPOINT=$( echo -E "$VCAP_SERVICES" | jq -r ".s3[$i].credentials.fips_endpoint" | uniq )
   echo " ... $REF_BUCKET"
   # the (cms)? of the regex was used for a specfic reference we kept finding that used /public instead of /cms/public


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the title above -->
## Jira Task
<!--- Provide a link to the Jira ticket -->
https://cm-jira.usa.gov/browse/USAGOV-387

## Description
<!--- Describe your changes in detail -->
The sed instructions on line 85 were wrong, lacking the "s" command that indicates "substitute." This is the cause of the "sed: unmatched 3" warning we see toward the end of a tome-synch run. 

You can test this on a local system, but you'd have to be pretty patient to run static site generation twice just for that! Plus, my system spits out a bunch of certificate warnings after this error, making it hard to find if you weren't watching the screen when it happens. Instead, I recommend opening a terminal in an alpine linux container (e.g., your locally running cms) and validating the approach by running the two following commands and observing that the first gives the "unmatched 3" error, while the second performs the desired substitution: 

```
/var/www #  echo foos3-us-bar  | sed '/s3\-us\-/s3.us-/'
sed: unmatched '3'
/var/www #  echo foos3-us-bar  | sed 's/s3\-us\-/s3.us-/'
foos3.us-bar
```

## Checklist for the Developer
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [ ] A link to the JIRA ticket has been added above.
- [ ] The JIRA ticket identifies the desired result of this change.
- [ ] The JIRA ticket contains clear acceptance criteria.
- [ ] The JIRA ticket contains clear testing steps.
- [ ] The JIRA ticket contains a description of "Done".
- [ ] Any preparation/installation/update steps required for this code to work properly (drush commands, scripts, configuration updates) are documented in the ticket.

## Checklist for the Peer Reviewers
- [ ] The branch name of this PR matches the project standards.
- [ ] QA steps are followed and any changes to process are updated in the ticket.
- [ ] Code Standards are followed, there are no bad practices in use.
- [ ] Config changes (if any) include only necessary changes.
- [ ] No errors in Drupal or Client Browser.
- [ ] Code has been tested locally (if possible).
- [ ] Following AC and Testing Steps verify changes work as expected.
- [ ] There are no known side-effects outside of expected behavior.
