### PR TITLE
Skip tome-run if usagov.tome_run_disabled is set

### DIFF
--- a/scripts/tome-run.sh
+++ b/scripts/tome-run.sh
@@ -35,6 +35,13 @@ TOMELOG=/tmp/tome-log/$TOMELOGFILE
 mkdir -p /tmp/tome-log/$YMD
 touch $TOMELOG
 
+# Don't even start if this flag is set:
+export NO_RUN=$(drush sget usagov.tome_run_disabled)
+if [ "$NO_RUN" != '' ]; then
+    echo "Tome run is disabled. Exiting." | tee -a $TOMELOG
+    exit 2
+fi
+
 # we should expect to see our process running: so we would expect a count of 1
 echo "Check if Tome is already running ... " | tee -a $TOMELOG
 PS_AUX=$(ps aux)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
## Jira Task
<!--- Provide a link to the Jira ticket -->
https://cm-jira.usa.gov/browse/USAGOV-690

## Description
<!--- Describe your changes in detail -->

Check for a usagov.tome_run_disabled state setting before running. This will allow us to pause static site generation during deployments ("drush sset usagov.tome_run_disabled" before beginning deployment, "drush sdel usagov.tome_run_disabled" after) or at other times of distress. 

I'm proposing we merge this as a hotfix to **prod** today. So, merge this branch directly to prod, dev, and stage. So that we can be sure to keep static site generation paused overnight after tonight's deployment. 

## Checklist for the Developer
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [ ] A link to the JIRA ticket has been added above.
- [ ] The JIRA ticket identifies the desired result of this change.
- [ ] The JIRA ticket contains clear acceptance criteria.
- [ ] The JIRA ticket contains clear testing steps.
- [ ] The JIRA ticket contains a description of "Done".
- [ ] Any preparation/installation/update steps required for this code to work properly (drush commands, scripts, configuration updates) are documented in the ticket.

## Checklist for the Peer Reviewers
- [ ] The branch name of this PR matches the project standards.
- [ ] QA steps are followed and any changes to process are updated in the ticket.
- [ ] Code Standards are followed, there are no bad practices in use.
- [ ] Config changes (if any) include only necessary changes.
- [ ] No errors in Drupal or Client Browser.
- [ ] Code has been tested locally (if possible).
- [ ] Following AC and Testing Steps verify changes work as expected.
- [ ] There are no known side-effects outside of expected behavior.
