### PR TITLE
USAGOV-740: Change the static-site caching TTL from 15 hours to 15 minutes

### DIFF
--- a/.docker/src-cms/etc/nginx/partials/www.conf.tmpl
+++ b/.docker/src-cms/etc/nginx/partials/www.conf.tmpl
@@ -10,7 +10,7 @@ server {
 
     proxy_hide_header Cache-Control;
     proxy_hide_header expires;
-    add_header Cache-Control max-age=54000;
+    add_header Cache-Control max-age=900;
 
     include /etc/nginx/partials/s3proxy.conf;
     include /etc/nginx/partials/404s.conf;
@@ -29,7 +29,7 @@ server {
 
     proxy_hide_header Cache-Control;
     proxy_hide_header expires;
-    add_header Cache-Control max-age=54000;    
+    add_header Cache-Control max-age=900;
 
     include /etc/nginx/partials/s3proxy.conf;
     include /etc/nginx/partials/404s.conf;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
## Jira Task
<!--- Provide a link to the Jira ticket -->
https://cm-jira.usa.gov/browse/USAGOV-740

## Description
<!--- Describe your changes in detail -->
Change the Cache-control max-age value for the static site from 54000 to 900. That is, from the current 15 hours to the intended 15 minutes. max-age is in seconds, and perhaps you should check my math!

This change is in the nginx config for the CMS app, but it applies specifically to the static site (www server block), so it would be a challenge to actually test the result in the local dev environment. 

## Checklist for the Developer
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [ ] A link to the JIRA ticket has been added above.
- [ ] The JIRA ticket identifies the desired result of this change.
- [ ] The JIRA ticket contains clear acceptance criteria.
- [ ] The JIRA ticket contains clear testing steps.
- [ ] The JIRA ticket contains a description of "Done".
- [ ] Any preparation/installation/update steps required for this code to work properly (drush commands, scripts, configuration updates) are documented in the ticket.

## Checklist for the Peer Reviewers
- [ ] The branch name of this PR matches the project standards.
- [ ] QA steps are followed and any changes to process are updated in the ticket.
- [ ] Code Standards are followed, there are no bad practices in use.
- [ ] Config changes (if any) include only necessary changes.
- [ ] No errors in Drupal or Client Browser.
- [ ] Code has been tested locally (if possible).
- [ ] Following AC and Testing Steps verify changes work as expected.
- [ ] There are no known side-effects outside of expected behavior.
