### PR TITLE
USAGOV-756-twig-fixes: Small fixes to a few of our templates.

### DIFF
--- a/web/themes/custom/usagov/templates/field--node--field-city--directory-record.html.twig
+++ b/web/themes/custom/usagov/templates/field--node--field-city--directory-record.html.twig
@@ -1,3 +1,3 @@
 <span class="field field--name-field-city field--type-string field--label-hidden field__item">
-  {{items[0]}},
+  {{items[0].content}},
 </span>

--- a/web/themes/custom/usagov/templates/field--node--field-email.html.twig
+++ b/web/themes/custom/usagov/templates/field--node--field-email.html.twig
@@ -1,5 +1,5 @@
 <span class="field field--name-field-email field--type-email field--label-hidden field__item">
-  <a href="mailto:{{items[0]}}">
-    {{items[0]}}
+  <a href="mailto:{{items[0].content}}">
+    {{items[0].content}}
   </a>
 </span>

--- a/web/themes/custom/usagov/templates/views-view-fields--life-events-view.html.twig
+++ b/web/themes/custom/usagov/templates/views-view-fields--life-events-view.html.twig
@@ -23,7 +23,7 @@
 	<div class="thumbnailDiv">
 		{% set image_card_uri = row._entity.field_navigation_banner_image.entity.field_media_image.entity.fileuri %}
 		{% set image_card_alt = row._entity.field_navigation_banner_image.entity.field_media_image.alt %}
-		<img class="thumbnailBanner" alt="{{image_card_alt}}" src={{file_url(image_card_uri|image_style('max_480w'))}}/>
+		<img class="thumbnailBanner" alt="{{image_card_alt}}" src="{{file_url(image_card_uri|image_style('max_480w'))}}"/>
 	</div>
 	{# <img class="thumbnailBanner" src={{file_url(row._entity.field_navigation_banner_image.entity.field_media_image.entity.fileuri)}}/></div> #}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
## Jira Task
<!--- Provide a link to the Jira ticket -->
https://cm-jira.usa.gov/browse/USAGOV-756

## Description
<!--- Describe your changes in detail -->
The two field- templates I changed are used in display of directory records. Drupal was logging an error whenever they were rendered on a page (although the page did render correctly). 

views-view-fields--life-events-view.html.twig is used for the homepage carousel. I noticed it was missing the quotation marks around the "src" attribute in the img tag, so I threw that in too. 

To review, refresh all caches. Then: 
For the first two, find or create a Federal Directory Record with an email address and City populated; verify that it displays correctly. 
For the second, review the home page. 

## Checklist for the Developer
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [ ] A link to the JIRA ticket has been added above.
- [ ] The JIRA ticket identifies the desired result of this change.
- [ ] The JIRA ticket contains clear acceptance criteria.
- [ ] The JIRA ticket contains clear testing steps.
- [ ] The JIRA ticket contains a description of "Done".
- [ ] Any preparation/installation/update steps required for this code to work properly (drush commands, scripts, configuration updates) are documented in the ticket.

## Checklist for the Peer Reviewers
- [ ] The branch name of this PR matches the project standards.
- [ ] QA steps are followed and any changes to process are updated in the ticket.
- [ ] Code Standards are followed, there are no bad practices in use.
- [ ] Config changes (if any) include only necessary changes.
- [ ] No errors in Drupal or Client Browser.
- [ ] Code has been tested locally (if possible).
- [ ] Following AC and Testing Steps verify changes work as expected.
- [ ] There are no known side-effects outside of expected behavior.
