### PR TITLE
USAGOV-762: Make separate blocks for mobile menus with different caching rules.

### DIFF
--- a/config/sync/block.block.betabanner.yml
+++ b/config/sync/block.block.betabanner.yml
@@ -12,7 +12,7 @@ dependencies:
 id: betabanner
 theme: usagov
 region: header_top
-weight: -16
+weight: -14
 provider: null
 plugin: 'block_content:189deb7d-0146-4d42-828d-c67ff9f0dcc6'
 settings:

--- a/config/sync/block.block.betaspanishbanner.yml
+++ b/config/sync/block.block.betaspanishbanner.yml
@@ -12,7 +12,7 @@ dependencies:
 id: betaspanishbanner
 theme: usagov
 region: header_top
-weight: -15
+weight: -13
 provider: null
 plugin: 'block_content:22e1b7bb-a272-4623-8abd-88248850d397'
 settings:

--- a/config/sync/block.block.englishbannercode.yml
+++ b/config/sync/block.block.englishbannercode.yml
@@ -12,7 +12,7 @@ dependencies:
 id: englishbannercode
 theme: usagov
 region: header_top
-weight: -18
+weight: -16
 provider: null
 plugin: 'block_content:d61595f0-7e1c-4081-9eef-cdc5ebbf822b'
 settings:

--- a/config/sync/block.block.languageswitcher.yml
+++ b/config/sync/block.block.languageswitcher.yml
@@ -9,7 +9,7 @@ dependencies:
 id: languageswitcher
 theme: usagov
 region: header_top
-weight: -14
+weight: -12
 provider: null
 plugin: 'language_block:language_interface'
 settings:

--- a/config/sync/block.block.mobile_navigation.yml
+++ b/config/sync/block.block.mobile_navigation.yml
@@ -7,12 +7,13 @@ dependencies:
   module:
     - language
     - menu_block
+    - node
   theme:
     - usagov
 id: mobile_navigation
 theme: usagov
 region: header_top
-weight: -13
+weight: -11
 provider: null
 plugin: 'menu_block:left-menu-english'
 settings:
@@ -37,3 +38,13 @@ visibility:
       language: '@language.current_language_context:language_interface'
     langcodes:
       en: en
+  'entity_bundle:node':
+    id: 'entity_bundle:node'
+    negate: false
+    context_mapping:
+      node: '@node.node_route_context:node'
+    bundles:
+      basic_page: basic_page
+      state_directory_record: state_directory_record
+      wizard: wizard
+      wizard_step: wizard_step

--- a/config/sync/block.block.mobile_navigation_dr_en.yml
+++ b/config/sync/block.block.mobile_navigation_dr_en.yml
@@ -1,0 +1,36 @@
+uuid: ba88b0a4-52e5-4783-9a97-d569a3371e56
+langcode: en
+status: true
+dependencies:
+  module:
+    - language
+    - node
+    - system
+  theme:
+    - usagov
+id: mobile_navigation_dr_en
+theme: usagov
+region: header_top
+weight: -10
+provider: null
+plugin: system_main_block
+settings:
+  id: system_main_block
+  label: 'Mobile Navigation - Directory Records - English'
+  label_display: visible
+  provider: system
+visibility:
+  'entity_bundle:node':
+    id: 'entity_bundle:node'
+    negate: false
+    context_mapping:
+      node: '@node.node_route_context:node'
+    bundles:
+      directory_record: directory_record
+  language:
+    id: language
+    negate: false
+    context_mapping:
+      language: '@language.current_language_context:language_interface'
+    langcodes:
+      en: en

--- a/config/sync/block.block.mobile_navigation_dr_es.yml
+++ b/config/sync/block.block.mobile_navigation_dr_es.yml
@@ -1,0 +1,36 @@
+uuid: b223852b-7aab-455d-bc81-5ef1a403c378
+langcode: en
+status: true
+dependencies:
+  module:
+    - language
+    - node
+    - system
+  theme:
+    - usagov
+id: mobile_navigation_dr_es
+theme: usagov
+region: header_top
+weight: -8
+provider: null
+plugin: system_main_block
+settings:
+  id: system_main_block
+  label: 'Mobile Navigation - Directory Records - Spanish'
+  label_display: visible
+  provider: system
+visibility:
+  'entity_bundle:node':
+    id: 'entity_bundle:node'
+    negate: false
+    context_mapping:
+      node: '@node.node_route_context:node'
+    bundles:
+      directory_record: directory_record
+  language:
+    id: language
+    negate: false
+    context_mapping:
+      language: '@language.current_language_context:language_interface'
+    langcodes:
+      es: es

--- a/config/sync/block.block.mobile_navigation_es.yml
+++ b/config/sync/block.block.mobile_navigation_es.yml
@@ -7,12 +7,13 @@ dependencies:
   module:
     - language
     - menu_block
+    - node
   theme:
     - usagov
 id: mobile_navigation_es
 theme: usagov
 region: header_top
-weight: 0
+weight: -9
 provider: null
 plugin: 'menu_block:left-menu-spanish'
 settings:
@@ -37,3 +38,13 @@ visibility:
       language: '@language.current_language_context:language_interface'
     langcodes:
       es: es
+  'entity_bundle:node':
+    id: 'entity_bundle:node'
+    negate: false
+    context_mapping:
+      node: '@node.node_route_context:node'
+    bundles:
+      basic_page: basic_page
+      state_directory_record: state_directory_record
+      wizard: wizard
+      wizard_step: wizard_step

--- a/config/sync/block.block.spanishbannercode.yml
+++ b/config/sync/block.block.spanishbannercode.yml
@@ -12,7 +12,7 @@ dependencies:
 id: spanishbannercode
 theme: usagov
 region: header_top
-weight: -17
+weight: -15
 provider: null
 plugin: 'block_content:08f40fa5-9c3d-4d4b-b5ed-60f8614b1fd0'
 settings:

--- a/web/themes/custom/usagov/templates/block--mobile-navigation-dr-en.html.twig
+++ b/web/themes/custom/usagov/templates/block--mobile-navigation-dr-en.html.twig
@@ -1,0 +1,1 @@
+{% include 'block--mobile-navigation.html.twig' %}

--- a/web/themes/custom/usagov/templates/block--mobile-navigation-dr-es.html.twig
+++ b/web/themes/custom/usagov/templates/block--mobile-navigation-dr-es.html.twig
@@ -1,0 +1,1 @@
+{% include 'block--mobile-navigation.html.twig' %}


### PR DESCRIPTION
The mobile menu is usually a rendering of either the "Left Menu English" or "Left Menu Spanish" menu. However, for (federal) Directory Records, the "menu" is a hard-coded structure PLUS the title of the current page. So for Directory Records, the mobile menu must appear in a block that is based on the current page and language, not on the left nav menu and language. This enables Drupal to cache the block appropriately.

<!--- Provide a general summary of your changes in the title above -->
## Jira Task
<!--- Provide a link to the Jira ticket -->
https://cm-jira.usa.gov/browse/USAGOV-762

## Description
<!--- Describe your changes in detail -->

## Checklist for the Developer
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [x] A link to the JIRA ticket has been added above.
- [ ] The JIRA ticket identifies the desired result of this change.
- [ ] The JIRA ticket contains clear acceptance criteria.
- [ ] The JIRA ticket contains clear testing steps.
- [ ] The JIRA ticket contains a description of "Done".
- [ ] Any preparation/installation/update steps required for this code to work properly (drush commands, scripts, configuration updates) are documented in the ticket.

## Checklist for the Peer Reviewers
- [ ] The branch name of this PR matches the project standards.
- [ ] QA steps are followed and any changes to process are updated in the ticket.
- [ ] Code Standards are followed, there are no bad practices in use.
- [ ] Config changes (if any) include only necessary changes.
- [ ] No errors in Drupal or Client Browser.
- [ ] Code has been tested locally (if possible).
- [ ] Following AC and Testing Steps verify changes work as expected.
- [ ] There are no known side-effects outside of expected behavior.
