### PR TITLE
USAGOV-824: Agency index view skips synonym that points to nonexistent directory record

### DIFF
--- a/web/modules/custom/usagov_directories/usagov_directories.module
+++ b/web/modules/custom/usagov_directories/usagov_directories.module
@@ -54,12 +54,13 @@ function usagov_directories_views_pre_render($view) {
       if ($type_str == "agency_synonym") {
         $pid_str = $new_result[$res]->_entity->field_agency_reference->target_id;
         // Need this check in case synonyms were not backlinked to their directory.
-        if ($pid_str) {
-          $parent = Node::load($pid_str);
+        if ($pid_str && ($parent = Node::load($pid_str))) {
           $new_result[$res]->_entity = clone $parent;
           $new_result[$res]->_entity->title[0]->value = $node_title;
         }
-
+        else {// Skip this synonym; it points to a record that no longer exists.
+          unset($new_result[$res]);
+        }
       }
     }
 


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the title above -->
## Jira Task
<!--- Provide a link to the Jira ticket -->
https://cm-jira.usa.gov/browse/USAGOV-824

## Description
<!--- Describe your changes in detail -->
If there is a Federal Directory Synonym pointing to a Directory Record that has been deleted, the agency-index letter page that should display the Synonym fails on an error. This update checks for existence of the Directory Record and skips the Synonym, so the letter page displays correctly. On a future ticket, we'll want to ensure that synonyms get deleted when their directory records are deleted. 

For example, my local dev environment had a directory record for "U.S. Court of Appeals for Veterans Claims". A synonym "Court of Appeals for Veterans Claims" exists for this record. I deleted the "U.S. Court of Appeals for Veterans Claims" Directory Record. 

With this change, the /agency-index?letter=c page displays correctly. Without it, you get an error "The website encountered an unexpected error. Please try again later."

## Checklist for the Developer
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [ ] A link to the JIRA ticket has been added above.
- [ ] The JIRA ticket identifies the desired result of this change.
- [ ] The JIRA ticket contains clear acceptance criteria.
- [ ] The JIRA ticket contains clear testing steps.
- [ ] The JIRA ticket contains a description of "Done".
- [ ] Any preparation/installation/update steps required for this code to work properly (drush commands, scripts, configuration updates) are documented in the ticket.

## Checklist for the Peer Reviewers
- [ ] The branch name of this PR matches the project standards.
- [ ] QA steps are followed and any changes to process are updated in the ticket.
- [ ] Code Standards are followed, there are no bad practices in use.
- [ ] Config changes (if any) include only necessary changes.
- [ ] No errors in Drupal or Client Browser.
- [ ] Code has been tested locally (if possible).
- [ ] Following AC and Testing Steps verify changes work as expected.
- [ ] There are no known side-effects outside of expected behavior.
