### PR TITLE
USAGOV-547-403-no-more: Use nginx to convert 403 status to 404

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -337,6 +337,7 @@ workflows:
                 - dev
                 - stage
                 - prod
+                - USAGOV-547-403-no-more
       - build-and-push-container:
           requires:
             - approve-build-and-push-container
@@ -346,6 +347,7 @@ workflows:
                 - dev
                 - stage
                 - prod
+                - USAGOV-547-403-no-more
       - approve-dev-deployment:
           type: approval
           requires:
@@ -354,6 +356,7 @@ workflows:
             branches:
               only:
               - dev
+              - USAGOV-547-403-no-more
       - deploy-to-cloudgov-dev:
           requires:
             - approve-dev-deployment
@@ -361,6 +364,7 @@ workflows:
             branches:
               only:
               - dev
+              - USAGOV-547-403-no-more
       - approve-stage-deployment:
           type: approval
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -337,7 +337,6 @@ workflows:
                 - dev
                 - stage
                 - prod
-                - USAGOV-547-403-no-more
       - build-and-push-container:
           requires:
             - approve-build-and-push-container
@@ -347,7 +346,6 @@ workflows:
                 - dev
                 - stage
                 - prod
-                - USAGOV-547-403-no-more
       - approve-dev-deployment:
           type: approval
           requires:
@@ -356,7 +354,6 @@ workflows:
             branches:
               only:
               - dev
-              - USAGOV-547-403-no-more
       - deploy-to-cloudgov-dev:
           requires:
             - approve-dev-deployment
@@ -364,7 +361,6 @@ workflows:
             branches:
               only:
               - dev
-              - USAGOV-547-403-no-more
       - approve-stage-deployment:
           type: approval
           requires:

--- a/.docker/src-cms/etc/nginx/partials/404s.conf.tmpl
+++ b/.docker/src-cms/etc/nginx/partials/404s.conf.tmpl
@@ -3,7 +3,8 @@
 
     location @notFoundEnglish {
       allow all;
-      error_page 404 403 @notFoundEnglishFallback;
+      error_page 404 @notFoundEnglishFallback;
+      error_page 403 =404 @notFoundEnglishFallback;
       proxy_intercept_errors on;
       recursive_error_pages on;
       set $errorfile "${S3_PROXY_WEB}${EN_404_PAGE}";
@@ -20,7 +21,8 @@
 
     location @notFoundSpanish {
       allow all;
-      error_page 404 403 @notFoundSpanishFallback;
+      error_page 404 @notFoundSpanishFallback;
+      error_page 403 =404 @notFoundSpanishFallback;
       proxy_intercept_errors on;
       recursive_error_pages on;
       set $errorfile "${S3_PROXY_WEB}${ES_404_PAGE}";

--- a/.docker/src-cms/etc/nginx/partials/404s.conf.tmpl
+++ b/.docker/src-cms/etc/nginx/partials/404s.conf.tmpl
@@ -3,8 +3,7 @@
 
     location @notFoundEnglish {
       allow all;
-      error_page 404 @notFoundEnglishFallback;
-      error_page 403 =404 @notFoundEnglishFallback;
+      error_page 403 404 @notFoundEnglishFallback;
       proxy_intercept_errors on;
       recursive_error_pages on;
       set $errorfile "${S3_PROXY_WEB}${EN_404_PAGE}";
@@ -21,8 +20,7 @@
 
     location @notFoundSpanish {
       allow all;
-      error_page 404 @notFoundSpanishFallback;
-      error_page 403 =404 @notFoundSpanishFallback;
+      error_page 403 404 @notFoundSpanishFallback;
       proxy_intercept_errors on;
       recursive_error_pages on;
       set $errorfile "${S3_PROXY_WEB}${ES_404_PAGE}";

--- a/.docker/src-cms/etc/nginx/partials/staticsite.conf.tmpl
+++ b/.docker/src-cms/etc/nginx/partials/staticsite.conf.tmpl
@@ -1,7 +1,8 @@
 
     # spanish main url - easier as a separate case vs in another regex
     location ~* ^/(es)$ {
-      error_page 404 403 @notFoundSpanish;
+      error_page 404 @notFoundSpanish;
+      error_page 403 =404 @notFoundSpanish;      
       proxy_intercept_errors on;
       recursive_error_pages on;
       set $indexfile "${S3_PROXY_WEB}${request_uri_lowercase}/index.html";
@@ -9,7 +10,8 @@
     }
     # spanish catch urls that end in a trailing slash - assume they are dirs and need an index
     location ~* ^/(es/(.+/)?)$ {
-      error_page 404 403 @notFoundSpanish;
+      error_page 404 @notFoundSpanish;
+      error_page 403 =404 @notFoundSpanish;      
       proxy_intercept_errors on;
       recursive_error_pages on;
       set $indexfile "${S3_PROXY_WEB}${request_uri_lowercase}index.html";
@@ -17,7 +19,8 @@
     }
     # spanish catch urls that end without an extension or trailing slash - assume they are dirs and need an index
     location ~* ^/(es/(.*/)?[^\./]+)$ {
-      error_page 404 403 @notFoundSpanish;
+      error_page 404 @notFoundSpanish;
+      error_page 403 =404 @notFoundSpanish;      
       proxy_intercept_errors on;
       recursive_error_pages on;
       set $indexfile "${S3_PROXY_WEB}${request_uri_lowercase}/index.html";
@@ -25,7 +28,8 @@
     }
     # spanish catch all urls - assume they are not dirs and should be proxied directly
     location ~* ^/(es/.*) {
-      error_page 404 403 @notFoundSpanish;
+      error_page 404 @notFoundSpanish;
+      error_page 403 =404 @notFoundSpanish;      
       proxy_intercept_errors on;
       recursive_error_pages on;
       set $indexfile "${S3_PROXY_WEB}${request_uri_lowercase}";
@@ -34,7 +38,8 @@
 
     # catch urls that end in a trailing slash - assume they are dirs and need an index
     location ~* /(.*/)?$ {
-      error_page 404 403 @notFoundEnglish;
+      error_page 404 @notFoundEnglish;
+      error_page 403 =404 @notFoundEnglish;      
       proxy_intercept_errors on;
       recursive_error_pages on;
       set $indexfile "${S3_PROXY_WEB}${request_uri_lowercase}index.html";
@@ -42,7 +47,8 @@
     }
     # catch urls that end without an extension or trailing slash - assume they are dirs and need an index
     location ~* /([^\./]+)$ {
-      error_page 404 403 @notFoundEnglish;
+      error_page 404 @notFoundEnglish;
+      error_page 403 =404 @notFoundEnglish;      
       proxy_intercept_errors on;
       recursive_error_pages on;
       set $indexfile "${S3_PROXY_WEB}${request_uri_lowercase}/index.html";
@@ -50,7 +56,8 @@
     }
     # catch all urls - assume they are not dirs and should be proxied directly
     location ~* (.*) {
-      error_page 404 403 @notFoundEnglish;
+      error_page 404 @notFoundEnglish;
+      error_page 403 =404 @notFoundEnglish;      
       proxy_intercept_errors on;
       recursive_error_pages on;
       set $indexfile "${S3_PROXY_WEB}${request_uri_lowercase}";


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
## Jira Task
<!--- Provide a link to the Jira ticket -->
https://cm-jira.usa.gov/browse/USAGOV-547

## Description
<!--- Describe your changes in detail -->
The static site has been returning a 403 status on "not found" pages, and it's been bothering me since, oh, October. I just noticed that the error_page directive should be able to just fix this for us. Not testable on local, but we'll be able to try it out on beta-dev.

## Checklist for the Developer
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [ ] A link to the JIRA ticket has been added above.
- [ ] The JIRA ticket identifies the desired result of this change.
- [ ] The JIRA ticket contains clear acceptance criteria.
- [ ] The JIRA ticket contains clear testing steps.
- [ ] The JIRA ticket contains a description of "Done".
- [ ] Any preparation/installation/update steps required for this code to work properly (drush commands, scripts, configuration updates) are documented in the ticket.

## Checklist for the Peer Reviewers
- [ ] The branch name of this PR matches the project standards.
- [ ] QA steps are followed and any changes to process are updated in the ticket.
- [ ] Code Standards are followed, there are no bad practices in use.
- [ ] Config changes (if any) include only necessary changes.
- [ ] No errors in Drupal or Client Browser.
- [ ] Code has been tested locally (if possible).
- [ ] Following AC and Testing Steps verify changes work as expected.
- [ ] There are no known side-effects outside of expected behavior.
