### PR TITLE
USAGOV-892: eliminate warning

### DIFF
--- a/web/modules/custom/usagov_ssg_postprocessing/usagov_ssg_postprocessing.module
+++ b/web/modules/custom/usagov_ssg_postprocessing/usagov_ssg_postprocessing.module
@@ -52,6 +52,9 @@ function usagov_ssg_postprocessing_page_attachments_alter(array &$attachments) {
     foreach ($attachments['#attached']['html_head_link'] as $key => $links) {
       $modified_links = [];
       foreach ($links as $link) {
+        if (!is_array($link)) {
+          continue;
+        }
         if (($link['rel'] == "alternate") && !str_ends_with($link['href'], '/')) {
           $link['href'] .= "/";
         }

--- a/web/modules/custom/usagov_ssg_postprocessing/usagov_ssg_postprocessing.module
+++ b/web/modules/custom/usagov_ssg_postprocessing/usagov_ssg_postprocessing.module
@@ -52,10 +52,7 @@ function usagov_ssg_postprocessing_page_attachments_alter(array &$attachments) {
     foreach ($attachments['#attached']['html_head_link'] as $key => $links) {
       $modified_links = [];
       foreach ($links as $link) {
-        if (!is_array($link)) {
-          continue;
-        }
-        if (($link['rel'] == "alternate") && !str_ends_with($link['href'], '/')) {
+        if (is_array($link) && ($link['rel'] == "alternate") && !str_ends_with($link['href'], '/')) {
           $link['href'] .= "/";
         }
         $modified_links[] = $link;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
## Jira Task
<!--- Provide a link to the Jira ticket -->
https://cm-jira.usa.gov/browse/USAGOV-892

## Description
<!--- Describe your changes in detail -->
The html_head_link array in can contain booleans as well as arrays. Add an "is_array" check to eliminate an error (warning) message being logged. 

(The point of the code here is to put trailing slashes on the alternate URLs on the home page, all of which are to either / or /es.) 

## Checklist for the Developer
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [ ] A link to the JIRA ticket has been added above.
- [ ] The JIRA ticket identifies the desired result of this change.
- [ ] The JIRA ticket contains clear acceptance criteria.
- [ ] The JIRA ticket contains clear testing steps.
- [ ] The JIRA ticket contains a description of "Done".
- [ ] Any preparation/installation/update steps required for this code to work properly (drush commands, scripts, configuration updates) are documented in the ticket.

## Checklist for the Peer Reviewers
- [ ] The branch name of this PR matches the project standards.
- [ ] QA steps are followed and any changes to process are updated in the ticket.
- [ ] Code Standards are followed, there are no bad practices in use.
- [ ] Config changes (if any) include only necessary changes.
- [ ] No errors in Drupal or Client Browser.
- [ ] Code has been tested locally (if possible).
- [ ] Following AC and Testing Steps verify changes work as expected.
- [ ] There are no known side-effects outside of expected behavior.
