### PR TITLE
USAGOV-948: SSG: Actually change the destination for letter pages

### DIFF
--- a/web/modules/custom/usagov_ssg_postprocessing/src/EventSubscriber/PagerPathSubscriber.php
+++ b/web/modules/custom/usagov_ssg_postprocessing/src/EventSubscriber/PagerPathSubscriber.php
@@ -25,7 +25,7 @@ class PagerPathSubscriber implements EventSubscriberInterface {
     $destination = $event->getDestination();
     $new_destination = $this->modifyUrl($destination);
     if ($destination != $new_destination) {
-      $event->setDestination($destination);
+      $event->setDestination($new_destination);
     }
   }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
## Jira Task
<!--- Provide a link to the Jira ticket -->
https://cm-jira.usa.gov/browse/USAGOV-948

## Description
<!--- Describe your changes in detail -->
A recent update of the PagerPathSubscriber  that converts query strings on the agency-index view to /letter paths broke the "modifyDestination" handler, with the result that the static site got only one agency-index page (last letter page generated won). This fixes it. 

## Checklist for the Developer
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [ ] A link to the JIRA ticket has been added above.
- [ ] The JIRA ticket identifies the desired result of this change.
- [ ] The JIRA ticket contains clear acceptance criteria.
- [ ] The JIRA ticket contains clear testing steps.
- [ ] The JIRA ticket contains a description of "Done".
- [ ] Any preparation/installation/update steps required for this code to work properly (drush commands, scripts, configuration updates) are documented in the ticket.

## Checklist for the Peer Reviewers
- [ ] The branch name of this PR matches the project standards.
- [ ] QA steps are followed and any changes to process are updated in the ticket.
- [ ] Code Standards are followed, there are no bad practices in use.
- [ ] Config changes (if any) include only necessary changes.
- [ ] No errors in Drupal or Client Browser.
- [ ] Code has been tested locally (if possible).
- [ ] Following AC and Testing Steps verify changes work as expected.
- [ ] There are no known side-effects outside of expected behavior.
