### PR TITLE
USAGOV-884-Carousel-stealing-focus

### DIFF
--- a/web/themes/custom/usagov/scripts/carousel.js
+++ b/web/themes/custom/usagov/scripts/carousel.js
@@ -26,14 +26,7 @@ jQuery(document).ready(function ($) {
   hideNonVisibleSlides();
 
   var currentSlideIndex = 0;
-  let indexInSS = sessionStorage.getItem("currentSlideIndexSS");
-  if (indexInSS != null) {
-    currentSlideIndex = indexInSS;
-    goToSlide(currentSlideIndex);
-  }
- else {
     previousButton.style.visibility = "hidden";
-  }
 
   if (slideDots.length > 0) {
     slideDots[currentSlideIndex].setAttribute("aria-current", true);
@@ -77,8 +70,6 @@ jQuery(document).ready(function ($) {
 
   // Go to a specific slide
   function goToSlide(nextLeftMostSlideIndex) {
-    // console.log(`nextLeftMostSlideIndex: ${nextLeftMostSlideIndex}`);
-    sessionStorage.setItem("currentSlideIndexSS", nextLeftMostSlideIndex);
 
     // Smoothly scroll to the requested slide
     if (window.innerWidth >= 1024) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
## Jira Task
<!--- Provide a link to the Jira ticket -->
https://cm-jira.usa.gov/browse/USAGOV-884

## Description
<!--- Describe your changes in detail -->
Interacting with the carousel on the homepage would store the index of the active carousel item. Then any time the homepage loads, the carousel script would set focus to the carousel item with that index.
I have removed that behavior from carousel javascript.

## How to test

- Go to the homepage carousel
- Click the Next/Previous arrows or pagination dots
- Refresh the page, or click the logo, or click the language toggle
- Confirm that the page does not automatically scroll down or set focus on the carousel
(If you're unsure what this means, try these steps on production to see the unwanted behavior)


## Checklist for the Developer
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [ ] A link to the JIRA ticket has been added above.
- [ ] The JIRA ticket identifies the desired result of this change.
- [ ] The JIRA ticket contains clear acceptance criteria.
- [ ] The JIRA ticket contains clear testing steps.
- [ ] The JIRA ticket contains a description of "Done".
- [ ] Any preparation/installation/update steps required for this code to work properly (drush commands, scripts, configuration updates) are documented in the ticket.

## Checklist for the Peer Reviewers
- [ ] The branch name of this PR matches the project standards.
- [ ] QA steps are followed and any changes to process are updated in the ticket.
- [ ] Code Standards are followed, there are no bad practices in use.
- [ ] Config changes (if any) include only necessary changes.
- [ ] No errors in Drupal or Client Browser.
- [ ] Code has been tested locally (if possible).
- [ ] Following AC and Testing Steps verify changes work as expected.
- [ ] There are no known side-effects outside of expected behavior.
