### PR TITLE
USAGOV-1000: Restore sayt filter for state governments

### DIFF
--- a/web/themes/custom/usagov/templates/views-view-list--50-state-pages.html.twig
+++ b/web/themes/custom/usagov/templates/views-view-list--50-state-pages.html.twig
@@ -32,7 +32,7 @@
 	<label id="state-info-label" class="usa-label" for="state-info">{{ lang == 'en' ? 'Select your state or territory:' : 'Elija un estado o territorio:' }}</label>
 	<div class="grid-row">
 		<div class="grid-col-fill mobile-lg:grid-col-auto">
-			<div class="usa-combo-box usa-combo-box--pristine width-full mobile-lg:width-mobile" data-default-value="alabama" data-enhanced="true">
+			<div class="usa-combo-box usa-combo-box--pristine width-full mobile-lg:width-mobile" data-default-value="alabama" data-enhanced="true" data-filter="{{ '{{' }}query}}.*|.*\s{{ '{{' }}query}}.*">
 				<ul id="statelist" class="one-column-bullet">
 					{% for row in rows %}
 						{{- row.content -}}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
## Jira Task
<!--- Provide a link to the Jira ticket -->
https://cm-jira.usa.gov/browse/USAGOV-1000

## Description
<!--- Describe your changes in detail -->
We lost a change that @cwacht made for USAGOV-877 when templates were shuffled around. I've just copied the change into the new location. 

The effect is that when you start typing in a dropdown for the states pages, only entries with a word that *begins with* what you typed are shown.

(As a reminder, if you have turned on twig debug mode, you need to turn it off to test these dropdowns.) 

## Checklist for the Developer
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [ ] A link to the JIRA ticket has been added above.
- [ ] The JIRA ticket identifies the desired result of this change.
- [ ] The JIRA ticket contains clear acceptance criteria.
- [ ] The JIRA ticket contains clear testing steps.
- [ ] The JIRA ticket contains a description of "Done".
- [ ] Any preparation/installation/update steps required for this code to work properly (drush commands, scripts, configuration updates) are documented in the ticket.

## Checklist for the Peer Reviewers
- [ ] The branch name of this PR matches the project standards.
- [ ] QA steps are followed and any changes to process are updated in the ticket.
- [ ] Code Standards are followed, there are no bad practices in use.
- [ ] Config changes (if any) include only necessary changes.
- [ ] No errors in Drupal or Client Browser.
- [ ] Code has been tested locally (if possible).
- [ ] Following AC and Testing Steps verify changes work as expected.
- [ ] There are no known side-effects outside of expected behavior.
