### PR TITLE
USAGOV-906: Add a general redirect from links that start with /espanol/ to the same path with /es/

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -473,7 +473,6 @@ workflows:
                 - dev
                 - stage
                 - prod
-                - USAGOV-906-general-espanol-redirect
       - build-and-push-container:
           requires:
             - approve-build-and-push-container
@@ -483,7 +482,6 @@ workflows:
                 - dev
                 - stage
                 - prod
-                - USAGOV-906-general-espanol-redirect
       - approve-dev-deployment:
           type: approval
           requires:
@@ -492,7 +490,6 @@ workflows:
             branches:
               only:
               - dev
-              - USAGOV-906-general-espanol-redirect
       - deploy-to-cloudgov-dev:
           requires:
             - approve-dev-deployment
@@ -500,7 +497,6 @@ workflows:
             branches:
               only:
               - dev
-              - USAGOV-906-general-espanol-redirect
       - approve-stage-deployment:
           type: approval
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -471,9 +471,9 @@ workflows:
             branches:
               only:
                 - dev
-                - nav-items-menu-block
                 - stage
                 - prod
+                - USAGOV-906-general-espanol-redirect
       - build-and-push-container:
           requires:
             - approve-build-and-push-container
@@ -481,9 +481,9 @@ workflows:
             branches:
               only:
                 - dev
-                - nav-items-menu-block
                 - stage
                 - prod
+                - USAGOV-906-general-espanol-redirect
       - approve-dev-deployment:
           type: approval
           requires:
@@ -492,7 +492,7 @@ workflows:
             branches:
               only:
               - dev
-              - nav-items-menu-block
+              - USAGOV-906-general-espanol-redirect
       - deploy-to-cloudgov-dev:
           requires:
             - approve-dev-deployment
@@ -500,7 +500,7 @@ workflows:
             branches:
               only:
               - dev
-              - nav-items-menu-block
+              - USAGOV-906-general-espanol-redirect
       - approve-stage-deployment:
           type: approval
           requires:

--- a/.docker/src-cms/etc/nginx/partials/internal_redirects.conf
+++ b/.docker/src-cms/etc/nginx/partials/internal_redirects.conf
@@ -250,3 +250,7 @@
     rewrite ^/visitors-driving$ /non-citizen-driving permanent;
     rewrite ^/voting$ /voting-and-elections permanent;
     rewrite ^/voting-laws-history$ /voting-laws permanent;
+
+
+    # Any ^espanol/* not otherwise specified links to /es/* (and may 404)
+    rewrite ^/espanol/(.+)$  /es/$1 permanent;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
## Jira Task
<!--- Provide a link to the Jira ticket -->
https://cm-jira.usa.gov/browse/USAGOV-906

Original request, from Shoshana, was to make links that start with /espanol and are not found show the Spanish 404 page. 

## Description
<!--- Describe your changes in detail -->

Added a catch-all redirect from ^/espanol/(.+)$ to /es/$1. So we either redirect to an appropriate path (that we hadn't already called out as a specific redirect), or the Spanish 404 at a path starting with /es. 

A little extra work would be required to test on a local setup: You would need to add the following line to .docker/src-cms/etc/nginx/partials/cms.conf: 

    include partials/internal_redirects.conf;

And then run bin/build (I think). 

It might be easier to deploy this branch to dev for review. Check in with me if you want me to do that. 

## Checklist for the Developer
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [ ] A link to the JIRA ticket has been added above.
- [ ] The JIRA ticket identifies the desired result of this change.
- [ ] The JIRA ticket contains clear acceptance criteria.
- [ ] The JIRA ticket contains clear testing steps.
- [ ] The JIRA ticket contains a description of "Done".
- [ ] Any preparation/installation/update steps required for this code to work properly (drush commands, scripts, configuration updates) are documented in the ticket.

## Checklist for the Peer Reviewers
- [ ] The branch name of this PR matches the project standards.
- [ ] QA steps are followed and any changes to process are updated in the ticket.
- [ ] Code Standards are followed, there are no bad practices in use.
- [ ] Config changes (if any) include only necessary changes.
- [ ] No errors in Drupal or Client Browser.
- [ ] Code has been tested locally (if possible).
- [ ] Following AC and Testing Steps verify changes work as expected.
- [ ] There are no known side-effects outside of expected behavior.
