### PR TITLE
USAGOV-106: Check for content in fields before doing entity lookup

### DIFF
--- a/web/themes/custom/usagov/usagov.theme
+++ b/web/themes/custom/usagov/usagov.theme
@@ -59,14 +59,14 @@ function usagov_preprocess_block(&$variables) {
           $data->description = $node->get('field_meta_description')->value;
         }
 
-        if ($node->hasField('field_navigation_banner_image')
+        if ($node->hasField('field_navigation_banner_image' && count($node->get('field_navigation_banner_image')))
           && $node->get('field_navigation_banner_image')[0]->entity
         ) {
           $data->navigation_banner_image = file_create_url(
             $node->get('field_navigation_banner_image')[0]->entity->get('field_media_image')->entity->getFileUri()
           );
         }
-        if ($node->hasField('field_css_icon')) {
+        if ($node->hasField('field_css_icon') && count($node->get('field_css_icon'))) {
           $data->css_icon = $node->get('field_css_icon')[0]->value;
         }
         if ($node->hasField('promote')) {


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the title above -->
## Jira Task
<!--- Provide a link to the Jira ticket -->
https://cm-jira.usa.gov/browse/USAGOV-106

## Description
<!--- Describe your changes in detail -->
Code on lines 63 and 70 of usagov.theme was raising warnings because some nodes had the navigation_banner_image or css_icon fields, but lacked any content for them. This turned out to be a valid state of affairs! I just added a check so we would not attempt to get the entity from the non-existent first element of those arrays. 

## Checklist for the Developer
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [ ] A link to the JIRA ticket has been added above.
- [ ] The JIRA ticket identifies the desired result of this change.
- [ ] The JIRA ticket contains clear acceptance criteria.
- [ ] The JIRA ticket contains clear testing steps.
- [ ] The JIRA ticket contains a description of "Done".
- [ ] Any preparation/installation/update steps required for this code to work properly (drush commands, scripts, configuration updates) are documented in the ticket.

## Checklist for the Peer Reviewers
- [ ] The branch name of this PR matches the project standards.
- [ ] QA steps are followed and any changes to process are updated in the ticket.
- [ ] Code Standards are followed, there are no bad practices in use.
- [ ] Config changes (if any) include only necessary changes.
- [ ] No errors in Drupal or Client Browser.
- [ ] Code has been tested locally (if possible).
- [ ] Following AC and Testing Steps verify changes work as expected.
- [ ] There are no known side-effects outside of expected behavior.
