### PR TITLE
USAGOV-106: caching tweak

### DIFF
--- a/web/themes/custom/usagov/usagov.theme
+++ b/web/themes/custom/usagov/usagov.theme
@@ -39,6 +39,9 @@ function usagov_preprocess_block(&$variables) {
   $variables['node'] = \Drupal::routeMatch()->getParameter('node');
 
   if ($variables['elements']['#id'] == 'navigation_page_items' || $variables['elements']['#id'] == 'navigation_page_items_spanish') {
+    $added_contexts = ['url.path']; // Use url.query_args as well for an easier test case
+    $variables['#cache']['contexts'] = array_merge($variables['#cache']['contexts'], $added_contexts);
+
     $items = $variables['content']['#items'];
     $children_of_active_menu_item = children_of_active_menu_item($items);
     $nav_page_items = [];

--- a/web/themes/custom/usagov/usagov.theme
+++ b/web/themes/custom/usagov/usagov.theme
@@ -84,7 +84,6 @@ function usagov_preprocess_block(&$variables) {
         $data->title = $menuItem['title'];
         $data->url = $menuItem['url'];
         if (strncmp($data->url, "base:", 5) === 0) {
-          $host = \Drupal::request()->getSchemeAndHttpHost();
           $data->url = "/" . substr($data->url, 5);
         }
         $data->description = $menuItem['description'];


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
## Jira Task
<!--- Provide a link to the Jira ticket -->
https://cm-jira.usa.gov/browse/USAGOV-106

## Description
<!--- Describe your changes in detail -->
Adds "url.path" to the cache contexts when navigation items are rendered in a menu block. This should cause the rendered content for that block to be cached based on the specific page, as well as on the menu and user. 

I was able to test something like this on my local setup by adding both "url.path" and "url.query_args." I didn't see undesired caching behavior at all, with or without this fix. But, having removed the cache-busting lines from my settings.local.php and having set a breakpoint in my debugger on line 41 of the theme file, I could see that without the additional cache contexts, an anonymous user would load a page with navigation, then not hit that point on successive reloads, even when supplying a query string on the URL. With  url.query_args added, differing query strings triggered re-rendering of the block. 

Whew. All we want is for the block to render differently based on the page it appears on (we don't do query strings), so url.path should do it. I just wasn't able to reproduce a case where this failed *without* url.path. Most likely I'm missing some other thing we've set on local dev that affects the cache. 

## Checklist for the Developer
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [ ] A link to the JIRA ticket has been added above.
- [ ] The JIRA ticket identifies the desired result of this change.
- [ ] The JIRA ticket contains clear acceptance criteria.
- [ ] The JIRA ticket contains clear testing steps.
- [ ] The JIRA ticket contains a description of "Done".
- [ ] Any preparation/installation/update steps required for this code to work properly (drush commands, scripts, configuration updates) are documented in the ticket.

## Checklist for the Peer Reviewers
- [ ] The branch name of this PR matches the project standards.
- [ ] QA steps are followed and any changes to process are updated in the ticket.
- [ ] Code Standards are followed, there are no bad practices in use.
- [ ] Config changes (if any) include only necessary changes.
- [ ] No errors in Drupal or Client Browser.
- [ ] Code has been tested locally (if possible).
- [ ] Following AC and Testing Steps verify changes work as expected.
- [ ] There are no known side-effects outside of expected behavior.
