### PR TITLE
USAGOV-738 SSG path rewrite for federal directories preserves fragment

### DIFF
--- a/web/modules/custom/usagov_ssg_postprocessing/src/EventSubscriber/PagerPathSubscriber.php
+++ b/web/modules/custom/usagov_ssg_postprocessing/src/EventSubscriber/PagerPathSubscriber.php
@@ -70,12 +70,16 @@ class PagerPathSubscriber implements EventSubscriberInterface {
    */
   protected function modifyUrl($url) {
     parse_str(parse_url($url, PHP_URL_QUERY), $query);
+    $fragment = parse_url($url, PHP_URL_FRAGMENT);
     if ($query && isset($query['letter'])) {
       $base_path = preg_replace('/\?.*/', '', $url);
       if ($base_path === '/') {
         $base_path = '';
       }
       $url = $base_path . '/' . $query['letter'];
+      if ($fragment) {
+        $url .= '#' . $fragment;
+      }
     }
     return $url;
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
## Jira Task
<!--- Provide a link to the Jira ticket -->
https://cm-jira.usa.gov/browse/USAGOV-738

## Description
<!--- Describe your changes in detail -->
The fragment part of a URL was being dropped from the links to federal agency letter pages during static site generation. 

This updates the code that rewrites URLs with query strings like "/some/path?letter=b" to "/some/path/b". This code didn't account for the possibility of a fragment on the path; now "/some/path?letter=b#B" will be rewritten to "/some/path/b#B" (instead of dropping the "#B"). 

## Checklist for the Developer
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [ ] A link to the JIRA ticket has been added above.
- [ ] The JIRA ticket identifies the desired result of this change.
- [ ] The JIRA ticket contains clear acceptance criteria.
- [ ] The JIRA ticket contains clear testing steps.
- [ ] The JIRA ticket contains a description of "Done".
- [ ] Any preparation/installation/update steps required for this code to work properly (drush commands, scripts, configuration updates) are documented in the ticket.

## Checklist for the Peer Reviewers
- [ ] The branch name of this PR matches the project standards.
- [ ] QA steps are followed and any changes to process are updated in the ticket.
- [ ] Code Standards are followed, there are no bad practices in use.
- [ ] Config changes (if any) include only necessary changes.
- [ ] No errors in Drupal or Client Browser.
- [ ] Code has been tested locally (if possible).
- [ ] Following AC and Testing Steps verify changes work as expected.
- [ ] There are no known side-effects outside of expected behavior.
