### PR TITLE
USAGOV-960: menu caching issues

### DIFF
--- a/web/themes/custom/usagov/usagov.theme
+++ b/web/themes/custom/usagov/usagov.theme
@@ -47,6 +47,7 @@ function usagov_preprocess_block(&$variables) {
 
   if ($variables['elements']['#id'] == 'navigation_page_items' || $variables['elements']['#id'] == 'navigation_page_items_spanish') {
     $added_contexts = ['url.path']; // Use url.query_args as well for an easier test case
+    $variables['content']['#cache']['contexts'] = array_merge($variables['content']['#cache']['contexts'], $added_contexts);
     $variables['#cache']['contexts'] = array_merge($variables['#cache']['contexts'], $added_contexts);
 
     $items = $variables['content']['#items'];


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
## Jira Task
<!--- Provide a link to the Jira ticket -->
https://cm-jira.usa.gov/browse/USAGOV-960

## Description
<!--- Describe your changes in detail -->
This is one more try at getting Drupal to take the current URL path into consideration when caching the block for the navigation cards. I don't have high hopes for this one, but it is at least harmless. Once it's been deployed, I'll start checking the logs again. 

## Checklist for the Developer
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [ ] A link to the JIRA ticket has been added above.
- [ ] The JIRA ticket identifies the desired result of this change.
- [ ] The JIRA ticket contains clear acceptance criteria.
- [ ] The JIRA ticket contains clear testing steps.
- [ ] The JIRA ticket contains a description of "Done".
- [ ] Any preparation/installation/update steps required for this code to work properly (drush commands, scripts, configuration updates) are documented in the ticket.

## Checklist for the Peer Reviewers
- [ ] The branch name of this PR matches the project standards.
- [ ] QA steps are followed and any changes to process are updated in the ticket.
- [ ] Code Standards are followed, there are no bad practices in use.
- [ ] Config changes (if any) include only necessary changes.
- [ ] No errors in Drupal or Client Browser.
- [ ] Code has been tested locally (if possible).
- [ ] Following AC and Testing Steps verify changes work as expected.
- [ ] There are no known side-effects outside of expected behavior.
