### PR TITLE
USAGOV-1051-agency-index-a-links: Correct the letter links at the top of agency index pages

### DIFF
--- a/web/themes/custom/usagov/templates/views-view-summary--federal-agencies.html.twig
+++ b/web/themes/custom/usagov/templates/views-view-summary--federal-agencies.html.twig
@@ -50,9 +50,9 @@
           <a {{row.attributes.addClass("is-active")}}>{{ row.link }}</a>
         {% else %}
           {% if row.link == "A" or row.link == "a" %}
-            <a href={{ agencyindex }}>{{ row.link }}</a>
+            <a href="{{ translations.agencyindex }}#{{ row.link }}">{{ row.link }}</a>
           {% else %}
-            <a href="{{ agencyindex }}?letter={{ row.link|lower }}#{{ row.link }}">{{ row.link }}</a>
+            <a href="{{ translations.agencyindex }}?letter={{ row.link|lower }}#{{ row.link }}">{{ row.link }}</a>
           {% endif %}
 	      {% endif %}
         {% if options.count %}


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the title above -->
## Jira Task
<!--- Provide a link to the Jira ticket -->
https://cm-jira.usa.gov/browse/USAGOV-1051

## Description
<!--- Describe your changes in detail -->
This corrects the URLs for the letter links at the top of the agency index pages. They were being constructed based on some variables, but weren't referring to the variables correctly. 

You will see the difference on letter pages other than "A", for example:
  http://localhost/agency-index?letter=c
  http://localhost/es/indice-agencias?letter=c

Before adding this change, the "A" link in the box near the top will just reload the current page. After applying the change (and clearing caches), it will go to /agency-index#A or /es/indice-agencias#A, respectively. 


## Checklist for the Developer
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [ ] A link to the JIRA ticket has been added above.
- [ ] The JIRA ticket identifies the desired result of this change.
- [ ] The JIRA ticket contains clear acceptance criteria.
- [ ] The JIRA ticket contains clear testing steps.
- [ ] The JIRA ticket contains a description of "Done".
- [ ] Any preparation/installation/update steps required for this code to work properly (drush commands, scripts, configuration updates) are documented in the ticket.

## Checklist for the Peer Reviewers
- [ ] The branch name of this PR matches the project standards.
- [ ] QA steps are followed and any changes to process are updated in the ticket.
- [ ] Code Standards are followed, there are no bad practices in use.
- [ ] Config changes (if any) include only necessary changes.
- [ ] No errors in Drupal or Client Browser.
- [ ] Code has been tested locally (if possible).
- [ ] Following AC and Testing Steps verify changes work as expected.
- [ ] There are no known side-effects outside of expected behavior.
