### PR TITLE
Usagov 291 hidden until found

### DIFF
--- a/web/themes/custom/usagov/sass/_uswds-theme-custom-styles.scss
+++ b/web/themes/custom/usagov/sass/_uswds-theme-custom-styles.scss
@@ -970,7 +970,7 @@ div[class^="QSIUserDefinedHTML"] {
 }
 
 [hidden="until-found"]{
-  display: block;
+  display: revert-layer;
   border: 0 !important;
   padding: 0 !important;
 }

--- a/web/themes/custom/usagov/templates/html.html.twig
+++ b/web/themes/custom/usagov/templates/html.html.twig
@@ -234,7 +234,7 @@ const scrollToTop = () => {
 <script type="text/javascript">
   document.querySelectorAll(".usa-accordion__content").forEach((accordionContent) => {
     accordionContent.onbeforematch = () => {
-      accordionContent.removeAttribute("hidden");
+      //accordionContent.removeAttribute("hidden");
       document.querySelector("[aria-controls='"+accordionContent.id+"']").setAttribute("aria-expanded", "true");
     };
     


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
## Jira Task
<!--- Provide a link to the Jira ticket -->
https://cm-jira.usa.gov/browse/USAGOV-291

## Description
<!--- Describe your changes in detail -->
This change fixes an issue with safari when making content in accordions searchable via ctrl-F 

## How To Test
Test the following in a variety of browsers:
Visit a page with accordions and use ctrl-F to search for a word that is in a closed accordion. The accordion should open to reveal the highlighted word.

Some examples to test:
 - The gov banner on all pages (search for "https")
 - /branches-of-government (search for "key")
 - /elected-officials-results?input-street=1600+Pennsylvania+Avenue+NW&input-city=Washington&input-state=DC&input-zip=20500
   - (search for "democrat")
 - /agency-index (search for "website")


## Checklist for the Developer
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [ ] A link to the JIRA ticket has been added above.
- [ ] The JIRA ticket identifies the desired result of this change.
- [ ] The JIRA ticket contains clear acceptance criteria.
- [ ] The JIRA ticket contains clear testing steps.
- [ ] The JIRA ticket contains a description of "Done".
- [ ] Any preparation/installation/update steps required for this code to work properly (drush commands, scripts, configuration updates) are documented in the ticket.

## Checklist for the Peer Reviewers
- [ ] The branch name of this PR matches the project standards.
- [ ] QA steps are followed and any changes to process are updated in the ticket.
- [ ] Code Standards are followed, there are no bad practices in use.
- [ ] Config changes (if any) include only necessary changes.
- [ ] No errors in Drupal or Client Browser.
- [ ] Code has been tested locally (if possible).
- [ ] Following AC and Testing Steps verify changes work as expected.
- [ ] There are no known side-effects outside of expected behavior.
