### PR TITLE
USAGOV-996: Correct the og:url values on the home pages

### DIFF
--- a/web/themes/custom/usagov/templates/html.html.twig
+++ b/web/themes/custom/usagov/templates/html.html.twig
@@ -25,9 +25,16 @@
 #}
 {% set lang = node.langcode.value %}
 {% set nodeID = node.nid[0].value %}
-{% set path = drupal_url('node/'~nodeID) %}
-{% set baseURL = url('<front>') %}
-{% set url = baseURL|render~path|render[1:] %}
+{% set path = drupal_url('node/'~nodeID, {absolute: TRUE}) %}
+{% set url = path|render|render %}
+{% if front == "homepage"            %}
+{%   set baseURL = url('<front>')    %}
+{%   set url = baseURL|render|render %}
+{%   if not (url ends with '/')      %}
+{%     set url = url ~ '/'           %}
+{%   endif                           %}
+{% endif                             %}
+
 <!DOCTYPE html>
 <html{{ html_attributes }}>
 <head>
@@ -41,7 +48,6 @@
   {% if node.id is defined %}
     {{ node.field_header_html.value|raw }}
   {% endif %}
-  
   <script>
     dataLayer = [{
       {{'nodeID'|json_encode(constant('JSON_PRETTY_PRINT'))|raw }}: {{nodeID|json_encode(constant('JSON_PRETTY_PRINT'))|raw }},
@@ -237,7 +243,7 @@ const scrollToTop = () => {
       //accordionContent.removeAttribute("hidden");
       document.querySelector("[aria-controls='"+accordionContent.id+"']").setAttribute("aria-expanded", "true");
     };
-    
+
   });
 	// Select the node that will be observed for mutations
 	//<![CDATA[


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
## Jira Task
<!--- Provide a link to the Jira ticket -->
https://cm-jira.usa.gov/browse/USAGOV-966

## Description
<!--- Describe your changes in detail -->
Corrects the calculations for URL value used in the <meta property="og:url" ...> tag on all pages (under the "Social Media" comment). For all but the home pages, this simplifies things a bit. Previously, the home pages specifically had messed-up values, with "/node/1" appearing in them. Spanish pages had "/eses/" instead of "/es/". 

Test by viewing source and verifying that the url in the "og:url" meta tag matches what you're seeing in the location bar (minus any query string or fragment). The distinct cases I know of are: 
 
 * English home page
 * Spanish home page
 * Some other English page
 * Some other Spanish page

## Checklist for the Developer
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [ ] A link to the JIRA ticket has been added above.
- [ ] The JIRA ticket identifies the desired result of this change.
- [ ] The JIRA ticket contains clear acceptance criteria.
- [ ] The JIRA ticket contains clear testing steps.
- [ ] The JIRA ticket contains a description of "Done".
- [ ] Any preparation/installation/update steps required for this code to work properly (drush commands, scripts, configuration updates) are documented in the ticket.

## Checklist for the Peer Reviewers
- [ ] The branch name of this PR matches the project standards.
- [ ] QA steps are followed and any changes to process are updated in the ticket.
- [ ] Code Standards are followed, there are no bad practices in use.
- [ ] Config changes (if any) include only necessary changes.
- [ ] No errors in Drupal or Client Browser.
- [ ] Code has been tested locally (if possible).
- [ ] Following AC and Testing Steps verify changes work as expected.
- [ ] There are no known side-effects outside of expected behavior.
