### PR TITLE
USAGOV-1100: Delete files after Tome fails, so the next run doesn't generate an incomplete corpus

### DIFF
--- a/scripts/tome-run.sh
+++ b/scripts/tome-run.sh
@@ -89,7 +89,7 @@ if [ "$CONTENT_UPDATED" != "0" ] || [[ "$FORCE" =~ ^\-{0,2}f\(orce\)?$ ]] || [ "
   else
     echo "Tome static build failed with status $TOME_SUCCESS - not pushing to S3" | tee -a $TOMELOG
     echo "Deleting Tome files to prevent inconsistency in next run" | tee -a $TOMELOG
-    rm -r /var/www/html/* | tee -a $TOMELOG
+    rm -rf /var/www/html/* | tee -a $TOMELOG
     if [ -f "$TOMELOG" ]; then
       echo "Saving logs of this run to S3" | tee -a $TOMELOG
       aws s3 cp $TOMELOG s3://$BUCKET_NAME/tome-log/$TOMELOGFILE --only-show-errors $S3_EXTRA_PARAMS

--- a/scripts/tome-run.sh
+++ b/scripts/tome-run.sh
@@ -88,6 +88,8 @@ if [ "$CONTENT_UPDATED" != "0" ] || [[ "$FORCE" =~ ^\-{0,2}f\(orce\)?$ ]] || [ "
     $SCRIPT_PATH/tome-sync.sh $TOMELOGFILE $YMDHMS $FORCE
   else
     echo "Tome static build failed with status $TOME_SUCCESS - not pushing to S3" | tee -a $TOMELOG
+    echo "Deleting Tome files to prevent inconsistency in next run" | tee -a $TOMELOG
+    rm -r /var/www/html/* | tee -a $TOMELOG
     if [ -f "$TOMELOG" ]; then
       echo "Saving logs of this run to S3" | tee -a $TOMELOG
       aws s3 cp $TOMELOG s3://$BUCKET_NAME/tome-log/$TOMELOGFILE --only-show-errors $S3_EXTRA_PARAMS


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
## Jira Task
<!--- Provide a link to the Jira ticket -->
https://cm-jira.usa.gov/browse/USAGOV-1100

## Description
<!--- Describe your changes in detail -->
When tome-static.sh fails, we already note that and don't push the files to s3. With this change, we also remove the contents of /var/www/html (I'm not worried about . files). The reason is that we have now observed that a failed run with partial content under agency-index can result in the next run's skipping agency-index without showing any error -- basically Tome doesn't pick up the need to generate additional pages. 

I had initially set out to do this when tome-static.sh reported failure with signal 9, but then realized that this is probably appropriate regardless of the non-zero return status.  

To test locally: Open a couple of terminals on your cms container. In one, run: 
  /bin/sh /var/www/scripts/tome-static.sh http://127.0.0.1

Watch for progress bars. When you start seeing them, check the contents of /var/www/html in your other terminal; there should some files. Then run: 

  ps | grep tome

And look for the parent tome process, which will look like this: 

 php /var/www/vendor/bin/drush tome:static -y --uri=http://127.0.0.1 --process-count=10

Then type "kill -9 XXXXXX" where XXXX is that process's number. In the first window, you should see the script report that tome failed with signal 9, and also the new comment "Deleting Tome files to prevent inconsistency in next run" (it may take a moment to get there). The /var/www/html directory should now be empty again. 


## Checklist for the Developer
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [ ] A link to the JIRA ticket has been added above.
- [ ] The JIRA ticket identifies the desired result of this change.
- [ ] The JIRA ticket contains clear acceptance criteria.
- [ ] The JIRA ticket contains clear testing steps.
- [ ] The JIRA ticket contains a description of "Done".
- [ ] Any preparation/installation/update steps required for this code to work properly (drush commands, scripts, configuration updates) are documented in the ticket.

## Checklist for the Peer Reviewers
- [ ] The branch name of this PR matches the project standards.
- [ ] QA steps are followed and any changes to process are updated in the ticket.
- [ ] Code Standards are followed, there are no bad practices in use.
- [ ] Config changes (if any) include only necessary changes.
- [ ] No errors in Drupal or Client Browser.
- [ ] Code has been tested locally (if possible).
- [ ] Following AC and Testing Steps verify changes work as expected.
- [ ] There are no known side-effects outside of expected behavior.
