### PR TITLE
USAGOV-677-Jaws-Aria-Labels: Update footer-identifier.html.twig

### DIFF
--- a/web/themes/custom/usagov/templates/footer-identifier.html.twig
+++ b/web/themes/custom/usagov/templates/footer-identifier.html.twig
@@ -1,6 +1,7 @@
 {% set lang = node.langcode.value %}
 <div class="usa-identifier">
-	<section class="usa-identifier__section usa-identifier__section--usagov" aria-label="USAGov is the Official Guide to Government Information and Services">
+	<section class="usa-identifier__section usa-identifier__section--usagov" {{ lang == 'es' ?  "aria-label='USAGov en Español es la guía oficial de información y servicios del Gobierno'" : "aria-label='USAGov is the official guide to government information and services'" }}
+	aria-label="USAGov is the Official Guide to Government Information and Services">
 		<div class="usa-identifier__container">
 			<div class="usa-identifier__usagov-description">
 				{{ lang == 'es' ?  "USAGov en Español es la guía oficial de información y servicios del Gobierno" : "USAGov is the official guide to government information and services" }}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
## Jira Task
<!--- Provide a link to the Jira ticket -->
https://cm-jira.usa.gov/browse/USAGOV-677

## Description
<!--- Describe your changes in detail -->
Adds translation for footer identifier aria label in Spanish. Aria label should now say "USAGov en Español es la guía oficial de información y servicios del Gobierno" on Spanish pages. 

## Checklist for the Developer
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [x] A link to the JIRA ticket has been added above.
- [x] The JIRA ticket identifies the desired result of this change.
- [x] The JIRA ticket contains clear acceptance criteria.
- [x] The JIRA ticket contains clear testing steps.
- [x]  The JIRA ticket contains a description of "Done".
- [x] Any preparation/installation/update steps required for this code to work properly (drush commands, scripts, configuration updates) are documented in the ticket.

## Checklist for the Peer Reviewers
- [ ] The branch name of this PR matches the project standards.
- [ ] QA steps are followed and any changes to process are updated in the ticket.
- [ ] Code Standards are followed, there are no bad practices in use.
- [ ] Config changes (if any) include only necessary changes.
- [ ] No errors in Drupal or Client Browser.
- [ ] Code has been tested locally (if possible).
- [ ] Following AC and Testing Steps verify changes work as expected.
- [ ] There are no known side-effects outside of expected behavior.
