### PR TITLE
USAGOV-1116-Phone-Numbers: dev: Add a check to see if textContent is …

### DIFF
--- a/web/themes/custom/usagov/scripts/phoneForMobileinBody.js
+++ b/web/themes/custom/usagov/scripts/phoneForMobileinBody.js
@@ -2,7 +2,6 @@ var pattern = /[0-9]?[-. ]\(?([0-9]{3})\)?[-. ]([0-9]{3})[-. ]([0-9]{4})/g;
 var safariCheck = /<a href="tel:[0-9]?[-. ]\(?([0-9]{3})\)?[-. ]([0-9]{3})[-. ]([0-9]{4})">[0-9]?[-. ]\(?([0-9]{3})\)?[-. ]([0-9]{3})[-. ]([0-9]{4})<\/a>/g;
 
 if (window.innerWidth <= 480) {
-  console.log(document.body.innerHTML.search(safariCheck));
   if (document.body.innerHTML.search(safariCheck) === -1) {
     document.body.innerHTML = document.body.innerHTML.replace(pattern, '<a href="tel:$&">$&</a>');
   }

--- a/web/themes/custom/usagov/scripts/telephoneForMobileNode.js
+++ b/web/themes/custom/usagov/scripts/telephoneForMobileNode.js
@@ -1,8 +1,15 @@
 function reformatNumForMobile(toReformat) {
   "use strict";
-  // get phone number and description from innerText
   const numAndDesc = toReformat.textContent || toReformat.innerText;
-  const numberSplitter = numAndDesc.split(" ");
+  const checkForBracket = numAndDesc.split(">");
+  let numberSplitter;
+  if (checkForBracket.length > 1) {
+    const removedBracket = checkForBracket[1];
+    numberSplitter = removedBracket.split(" ");
+  }
+  else {
+    numberSplitter = numAndDesc.split(" ");
+  }
   const onlyNum = numberSplitter[0];
   const cleanNumber = onlyNum.replace(/\D/g, "");
   const onlyDesc = numberSplitter.slice(1, numberSplitter.length).join(" ");


### PR DESCRIPTION
…returning a longer than necessary string

<!--- Provide a general summary of your changes in the title above -->
## Jira Task
<!--- Provide a link to the Jira ticket -->
https://cm-jira.usa.gov/browse/USAGOV-1116

## Description
<!--- Describe your changes in detail -->

Check Jira and #usagov-workspace on slack to see more context but fixes the bug where .textContext pulls too much html junk along with the phone number. Adds another check and parser to get just the phone number for rewrite. 

**Note** there are 4 entries that won't show as links due to not being in the cms correctly. Asociación Nacional Gubernamental Hipotecaria o "Ginnie Mae",  Fundación Interamericana (IAF) & Oficina de Administración de Energía Oceánica (BOEM) all have extra spaces in the telephone field before the actual numbers.  Programa de Intérpretes de las Cortes de EE. UU has spaces within the phone number.

## Checklist for the Developer
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [x] A link to the JIRA ticket has been added above.
- [x] The JIRA ticket identifies the desired result of this change.
- [x] The JIRA ticket contains clear acceptance criteria.
- [x] The JIRA ticket contains clear testing steps.
- [x] The JIRA ticket contains a description of "Done".
- [x] Any preparation/installation/update steps required for this code to work properly (drush commands, scripts, configuration updates) are documented in the ticket.

## Checklist for the Peer Reviewers
- [ ] The branch name of this PR matches the project standards.
- [ ] QA steps are followed and any changes to process are updated in the ticket.
- [ ] Code Standards are followed, there are no bad practices in use.
- [ ] Config changes (if any) include only necessary changes.
- [ ] No errors in Drupal or Client Browser.
- [ ] Code has been tested locally (if possible).
- [ ] Following AC and Testing Steps verify changes work as expected.
- [ ] There are no known side-effects outside of expected behavior.
