### PR TITLE
USAGOV-1126: Allow empty path alias for home page.

### DIFF
--- a/web/modules/custom/usa_twig_vars/usa_twig_vars.module
+++ b/web/modules/custom/usa_twig_vars/usa_twig_vars.module
@@ -242,10 +242,22 @@ function usa_twig_vars_form_alter(&$form, &$form_state, $form_id) {
  * Custom after build function
  */
 function usa_twig_vars_after_build($form, &$form_state) {
-  // Unchecks Generate automatic URL alias if path exists
+  // Unchecks Generate automatic URL alias if path exists, if NOT home page
+  if (in_array('field_page_type', $form_state->getValues())) {
+    $page_type = NULL;
+    if (is_array($form_state->getValues()['field_page_type'])) {
+      $page_type = $form_state->getValues()['field_page_type'][0];
+    }
+    else {
+      $page_type = $form_state->getValues()['field_page_type'];
+    }
+    if ($page_type == "22") {
+      return $form;
+    }
+  }
   if (in_array($form['#id'], [
-    'node-basic-page-form', 'node-basic-page-edit-form'
-    ])) {
+    'node-basic-page-form', 'node-basic-page-edit-form',
+  ])) {
     $form['path']['widget'][0]['#open'] = TRUE;
     if (array_key_exists('path', $form)) {
       $form['path']['widget'][0]['pathauto']['#checked'] = FALSE;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
## Jira Task
<!--- Provide a link to the Jira ticket -->
https://cm-jira.usa.gov/browse/USAGOV-1126

## Description
<!--- Describe your changes in detail -->
When saving the home page (either language), the user should not be required to fill in the URL alias field (in fact, they are supposed to leave these blank, although this code does not enforce that). 
When saving any other page, the user must either check the "Automatic alias" box or fill in a URL alias (as before). 

You might have to explicitly rebuild the theme registry (Under Flush cache in the menu) to get this change. 

## Checklist for the Developer
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [ ] A link to the JIRA ticket has been added above.
- [ ] The JIRA ticket identifies the desired result of this change.
- [ ] The JIRA ticket contains clear acceptance criteria.
- [ ] The JIRA ticket contains clear testing steps.
- [ ] The JIRA ticket contains a description of "Done".
- [ ] Any preparation/installation/update steps required for this code to work properly (drush commands, scripts, configuration updates) are documented in the ticket.

## Checklist for the Peer Reviewers
- [ ] The branch name of this PR matches the project standards.
- [ ] QA steps are followed and any changes to process are updated in the ticket.
- [ ] Code Standards are followed, there are no bad practices in use.
- [ ] Config changes (if any) include only necessary changes.
- [ ] No errors in Drupal or Client Browser.
- [ ] Code has been tested locally (if possible).
- [ ] Following AC and Testing Steps verify changes work as expected.
- [ ] There are no known side-effects outside of expected behavior.
