### PR TITLE
USAGOV-1111-mobile-navigation: mobile navigation fixed

### DIFF
--- a/web/themes/custom/usagov/templates/top_nav_es.html.twig
+++ b/web/themes/custom/usagov/templates/top_nav_es.html.twig
@@ -4,7 +4,7 @@
 			<a href="/es" title="USAGov Logo"><img class="es" src="/themes/custom/usagov/images/Logo_USAGov_Spanish.png" alt="USAGov en Español Logo"></a>
 		</em>
 	</div>
-	<button class="usa-menu-btn">Menu</button>
+	<button class="usa-menu-btn">Menú</button>
 </div>
 <nav aria-label="Navegación primaria" class="usa-nav">
 	<div class="usa-nav__inner">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
## Jira Task
<!--- Provide a link to the Jira ticket -->
https://cm-jira.usa.gov/browse/USAGOV-1111

## Description
<!--- Describe your changes in detail -->
The word "Menu" is missing the tilde on the letter u to read "Menú" on the Spanish website's mobile navigation (usa.gov/es).

Please test the following:
- [x] The word "Menu" have the tilde ("Menú") on the Spanish website's mobile navigation.
- [x] The word "Menu" doesn't have the tilde on the English website's mobile navigation.

Make sure to clear cache.

## Checklist for the Developer
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [x] A link to the JIRA ticket has been added above.
- [x] The JIRA ticket identifies the desired result of this change.
- [x] The JIRA ticket contains clear acceptance criteria.
- [x] The JIRA ticket contains clear testing steps.
- [x] The JIRA ticket contains a description of "Done".
- [x] Any preparation/installation/update steps required for this code to work properly (drush commands, scripts, configuration updates) are documented in the ticket.

## Checklist for the Peer Reviewers
- [ ] The branch name of this PR matches the project standards.
- [ ] QA steps are followed and any changes to process are updated in the ticket.
- [ ] Code Standards are followed, there are no bad practices in use.
- [ ] Config changes (if any) include only necessary changes.
- [ ] No errors in Drupal or Client Browser.
- [ ] Code has been tested locally (if possible).
- [ ] Following AC and Testing Steps verify changes work as expected.
- [ ] There are no known side-effects outside of expected behavior.
