### PR TITLE
USAGOV-1032: Workflow module should only remove delete and publish options for user's own work

### DIFF
--- a/web/modules/custom/usa_workflow/usa_workflow.module
+++ b/web/modules/custom/usa_workflow/usa_workflow.module
@@ -15,18 +15,23 @@ function usa_workflow_form_alter(&$form, FormStateInterface $form_state, $form_i
     'node_basic_page_form',
     'node_wizard_step_form',
     'node_wizard_form',
+    'content_moderation_entity_moderation_form',
   ];
 
   if (in_array($form_id, $newForm)) {
     $wfPermissions = Drupal::service('usa_workflow.permission.service')->wfUserPermission();
 
-    if ($wfPermissions['usaApproveOwnContent'] == FALSE) {
-      unset($form['moderation_state']['widget'][0]['state']['#options']['published']);
-      unset($form['new_state']['#options']['published']);
-    }
+    // Permissions are *stricter* here on the user's own content. Only some users can
+    // approve their own changes; any editor should be able to approve another editor's changes.
+    if ($wfPermissions['currentUser']['id'] == $wfPermissions['revisionUser']['id']) {
+      if ($wfPermissions['usaApproveOwnContent'] == FALSE) {
+        unset($form['moderation_state']['widget'][0]['state']['#options']['published']);
+        unset($form['new_state']['#options']['published']);
+      }
 
-    if ($wfPermissions['usaDeleteOwnContent'] == FALSE) {
-      unset($form['actions']['delete']);
+      if ($wfPermissions['usaDeleteOwnContent'] == FALSE) {
+        unset($form['actions']['delete']);
+      }
     }
   }
 }

--- a/web/modules/custom/usa_workflow/usa_workflow.module
+++ b/web/modules/custom/usa_workflow/usa_workflow.module
@@ -23,7 +23,7 @@ function usa_workflow_form_alter(&$form, FormStateInterface $form_state, $form_i
 
     // Permissions are *stricter* here on the user's own content. Only some users can
     // approve their own changes; any editor should be able to approve another editor's changes.
-    if ($wfPermissions['currentUser']['id'] == $wfPermissions['revisionUser']['id']) {
+    if ($wfPermissions['isNewPage'] || ($wfPermissions['currentUser']['id'] == $wfPermissions['revisionUser']['id'])) {
       if ($wfPermissions['usaApproveOwnContent'] == FALSE) {
         unset($form['moderation_state']['widget'][0]['state']['#options']['published']);
         unset($form['new_state']['#options']['published']);


### PR DESCRIPTION
Subject says it. The intent of the "own content" privileges is that less-privileged editors should not be able to delete or publish their own work -- a second editor, not necessarily of any higher role, needs to do that. So we need to check whether the current user is the same as the author of the latest revision on the moderation form. 

I don't know whether some of those form ids come into play at all. But the most recent version of this was removing the Delete button for me, a site admin! The nerve!

<!--- Provide a general summary of your changes in the title above -->
## Jira Task
<!--- Provide a link to the Jira ticket -->
https://cm-jira.usa.gov/browse/USAGOV-1032

## Description
<!--- Summarize the chages made in this pull request, not what it's for. -->

## Type of Changes
<!--- Put an `x` in all the boxes that apply. -->
- [ ] New Feature
- [x] Bugfix
- [ ] Frontend (Twig, Sass, JS)
  - Add screenshot showing what it should look like
- [ ] Drupal Config (requires "drush cim")
- [ ] New Modules (requires rebuild)
- [ ] Infrastructure
  - [ ] CMS
  - [ ] WAF
  - [ ] Egress
  - [ ] Tools
- [ ] Other

## Testing Instructions
<!-- This instructions are different from “testing instructions” in Jira – those are typically for Content/UX stakeholders -->
<!-- Not “see Jira” – if they are really the same, copy and paste. -->

### Requires New Config
- [ ] Yes
- [ ] No

### Requires New Content
- [ ] Yes
- [ ] No

### Validation Steps
- Test instruction 1
- Test instruction 2
- Test instruction 3

## Security Review
<!-- Checkboxes to indicate need for review -->

- [ ] Adds/updates software (including a library or Drupal module)
- [ ] Communication with external service
- [ ] Changes permissions or workflow
- [ ] Requires SSPP updates


## Reviewer Reminders
- Reviewed code changes
- Reviewed functionality
- Security review complete or not required

## Post PR Approval Instructions
Follow these steps as soon as you merge the new changes.

1. Go to the [USAGov Circle CI project](https://app.circleci.com/pipelines/github/usagov/usagov-2021).
2. Find the commit of this pull request.
3. Build and deploy the changes.
4. Update the Jira ticket by changing the ticket status to `Review in Test` and add a comment. State whether the change is already visible on [cms-dev.usa.gov](http://cms-dev.usa.gov/) and [beta-dev.usa.gov](http://beta-dev.usa.gov/), or if the deployment is still in process.
