### PR TITLE
USAGOV-1177: Correction to correctActiveTrail patch

### DIFF
--- a/patches/drupal/correctActiveTrail_d10.patch
+++ b/patches/drupal/correctActiveTrail_d10.patch
@@ -1,3 +1,18 @@
+diff --git a/core/lib/Drupal/Core/Menu/MenuActiveTrail.php b/core/lib/Drupal/Core/Menu/MenuActiveTrail.php
+index 978aeffbf4..82f5b9b18f 100644
+--- a/core/lib/Drupal/Core/Menu/MenuActiveTrail.php
++++ b/core/lib/Drupal/Core/Menu/MenuActiveTrail.php
+@@ -131,7 +131,9 @@ public function getActiveLink($menu_name = NULL) {
+       $route_parameters = $this->routeMatch->getRawParameters()->all();
+ 
+       // Load links matching this route.
+-      $links = $this->menuLinkManager->loadLinksByRoute($route_name, $route_parameters, $menu_name);
++      $link_sort_order = ['mlid' => 'ASC'];
++      $links = $this->menuLinkManager->loadLinksByRoute($route_name, $route_parameters, $menu_name, $link_sort_order);
++
+       // Select the first matching link.
+       if ($links) {
+         $found = reset($links);
 diff --git a/core/lib/Drupal/Core/Menu/MenuLinkFieldDefinitions.php b/core/lib/Drupal/Core/Menu/MenuLinkFieldDefinitions.php
 index 58a3c627d5..7b6b5dff21 100644
 --- a/core/lib/Drupal/Core/Menu/MenuLinkFieldDefinitions.php
@@ -9,7 +24,7 @@ index 58a3c627d5..7b6b5dff21 100644
 +    // USAGov addition: mlid, for correct sorting of "false children."
 +    'mlid' => '',
    ];
-
+ 
  }
 diff --git a/core/lib/Drupal/Core/Menu/MenuLinkManager.php b/core/lib/Drupal/Core/Menu/MenuLinkManager.php
 index c89dadd7b0..680ce1a396 100644

--- a/patches/drupal/correctActiveTrail_d10.patch
+++ b/patches/drupal/correctActiveTrail_d10.patch
@@ -1,15 +1,14 @@
 diff --git a/core/lib/Drupal/Core/Menu/MenuActiveTrail.php b/core/lib/Drupal/Core/Menu/MenuActiveTrail.php
-index 978aeffbf4..82f5b9b18f 100644
+index 978aeffbf4..cc8afb0292 100644
 --- a/core/lib/Drupal/Core/Menu/MenuActiveTrail.php
 +++ b/core/lib/Drupal/Core/Menu/MenuActiveTrail.php
-@@ -131,1 +131,1 @@ public function getActiveLink($menu_name = NULL) {
+@@ -131,7 +131,8 @@ public function getActiveLink($menu_name = NULL) {
        $route_parameters = $this->routeMatch->getRawParameters()->all();
 
        // Load links matching this route.
 -      $links = $this->menuLinkManager->loadLinksByRoute($route_name, $route_parameters, $menu_name);
 +      $link_sort_order = ['mlid' => 'ASC'];
 +      $links = $this->menuLinkManager->loadLinksByRoute($route_name, $route_parameters, $menu_name, $link_sort_order);
-+
        // Select the first matching link.
        if ($links) {
          $found = reset($links);
@@ -24,7 +23,6 @@ index 58a3c627d5..7b6b5dff21 100644
 +    // USAGov addition: mlid, for correct sorting of "false children."
 +    'mlid' => '',
    ];
-
  }
 diff --git a/core/lib/Drupal/Core/Menu/MenuLinkManager.php b/core/lib/Drupal/Core/Menu/MenuLinkManager.php
 index c89dadd7b0..680ce1a396 100644
@@ -43,7 +41,7 @@ index c89dadd7b0..680ce1a396 100644
        $instances[$plugin_id] = $this->createInstance($plugin_id);
      }
 diff --git a/core/lib/Drupal/Core/Menu/MenuTreeStorage.php b/core/lib/Drupal/Core/Menu/MenuTreeStorage.php
-index 1a035a0f72..6cd84a413d 100644
+index 1a035a0f72..b2b08b9de1 100644
 --- a/core/lib/Drupal/Core/Menu/MenuTreeStorage.php
 +++ b/core/lib/Drupal/Core/Menu/MenuTreeStorage.php
 @@ -654,7 +654,7 @@ public function loadByProperties(array $properties) {
@@ -62,7 +60,7 @@ index 1a035a0f72..6cd84a413d 100644
 -    $query->orderBy('depth');
 -    $query->orderBy('weight');
 -    $query->orderBy('id');
-+    $default_sort_order = [ 'depth' =>'ASC', 'weight' => 'ASC', 'id' => 'ASC'];
++    $default_sort_order = ['depth' => 'ASC', 'weight' => 'ASC', 'id' => 'ASC'];
 +    if (empty($sort_order)) {
 +      $sort_order = $default_sort_order;
 +    }
@@ -83,3 +81,16 @@ index 1a035a0f72..6cd84a413d 100644
      $loaded = $this->safeExecuteSelect($query)->fetchAllAssoc('id', \PDO::FETCH_ASSOC);
      foreach ($loaded as $id => $link) {
        $loaded[$id] = $this->prepareLink($link);
+diff --git a/core/lib/Drupal/Core/Menu/MenuTreeStorageInterface.php b/core/lib/Drupal/Core/Menu/MenuTreeStorageInterface.php
+index 8eb9289b17..ef0724c959 100644
+--- a/core/lib/Drupal/Core/Menu/MenuTreeStorageInterface.php
++++ b/core/lib/Drupal/Core/Menu/MenuTreeStorageInterface.php
+@@ -86,7 +86,7 @@ public function loadByProperties(array $properties);
+    * @return array
+    *   An array of menu link definitions keyed by ID and ordered by depth.
+    */
+-  public function loadByRoute($route_name, array $route_parameters = [], $menu_name = NULL);
++  public function loadByRoute($route_name, array $route_parameters = [], $menu_name = NULL, $sort_order = NULL);
+
+   /**
+    * Saves a plugin definition to the storage.

--- a/patches/drupal/correctActiveTrail_d10.patch
+++ b/patches/drupal/correctActiveTrail_d10.patch
@@ -2,9 +2,9 @@ diff --git a/core/lib/Drupal/Core/Menu/MenuActiveTrail.php b/core/lib/Drupal/Cor
 index 978aeffbf4..82f5b9b18f 100644
 --- a/core/lib/Drupal/Core/Menu/MenuActiveTrail.php
 +++ b/core/lib/Drupal/Core/Menu/MenuActiveTrail.php
-@@ -131,7 +131,9 @@ public function getActiveLink($menu_name = NULL) {
+@@ -131,1 +131,1 @@ public function getActiveLink($menu_name = NULL) {
        $route_parameters = $this->routeMatch->getRawParameters()->all();
- 
+
        // Load links matching this route.
 -      $links = $this->menuLinkManager->loadLinksByRoute($route_name, $route_parameters, $menu_name);
 +      $link_sort_order = ['mlid' => 'ASC'];
@@ -17,14 +17,14 @@ diff --git a/core/lib/Drupal/Core/Menu/MenuLinkFieldDefinitions.php b/core/lib/D
 index 58a3c627d5..7b6b5dff21 100644
 --- a/core/lib/Drupal/Core/Menu/MenuLinkFieldDefinitions.php
 +++ b/core/lib/Drupal/Core/Menu/MenuLinkFieldDefinitions.php
-@@ -45,6 +45,8 @@ trait MenuLinkFieldDefinitions {
+@@ -45,4 +45,6 @@ trait MenuLinkFieldDefinitions {
      'form_class' => 'Drupal\Core\Menu\Form\MenuLinkDefaultForm',
      // The plugin ID. Set by the plugin system based on the top-level YAML key.
      'id' => '',
 +    // USAGov addition: mlid, for correct sorting of "false children."
 +    'mlid' => '',
    ];
- 
+
  }
 diff --git a/core/lib/Drupal/Core/Menu/MenuLinkManager.php b/core/lib/Drupal/Core/Menu/MenuLinkManager.php
 index c89dadd7b0..680ce1a396 100644


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
## Jira Task
<!--- Provide a link to the Jira ticket -->
https://cm-jira.usa.gov/browse/USAGOV-1177

## Description
Adds a couple of lines that one of us (me?) missed in the correctActiveTrail patch; updates a call in MenuActiveTrail that needs to pass sort parameters.

## Type of Changes
<!--- Put an `x` in all the boxes that apply. -->
- [ ] New Feature
- [x] Bugfix
- [ ] Frontend (Twig, Sass, JS)
  - Add screenshot showing what it should look like
- [ ] Drupal Config (requires "drush cim")
- [ ] New Modules (requires rebuild)
- [ ] Infrastructure
  - [ ] CMS
  - [ ] WAF
  - [ ] Egress
  - [ ] Tools
- [ ] Other

## Testing Instructions
run bin/drupal-update. You should see this patch being applied.  (if bin/drupal-update doesn't work for some reason, you can usually also use "bin/composer reinstall drupal/core")


### Requires New Config
- [ ] Yes
- [x] No

### Requires New Content
- [ ] Yes
- [x] No

### Validation Steps
view /financial-hardship on localhost. It should have "Life events" in the breadcrumbs and have its nav cards. 

## Security Review
<!-- Checkboxes to indicate need for review -->

- [ ] Adds/updates software (including a library or Drupal module)
- [ ] Communication with external service
- [ ] Changes permissions or workflow
- [ ] Requires SSPP updates


## Reviewer Reminders
- Reviewed code changes
- Reviewed functionality
- Security review complete or not required

## Post PR Approval Instructions
Follow these steps as soon as you merge the new changes.

1. Go to the [USAGov Circle CI project](https://app.circleci.com/pipelines/github/usagov/usagov-2021).
2. Find the commit of this pull request.
3. Build and deploy the changes.
4. Update the Jira ticket by changing the ticket status to `Review in Test` and add a comment. State whether the change is already visible on [cms-dev.usa.gov](http://cms-dev.usa.gov/) and [beta-dev.usa.gov](http://beta-dev.usa.gov/), or if the deployment is still in process.
