### PR TITLE
USAGOV-1197-Share-Https: Update sharethispage.html.twig

### DIFF
--- a/web/themes/custom/usagov/templates/sharethispage.html.twig
+++ b/web/themes/custom/usagov/templates/sharethispage.html.twig
@@ -18,8 +18,8 @@
 {% set path = drupal_url('node/'~nodeID) %}
 
 {% if path|render not in exclusions %}
-	{% set facebook = 'http://www.facebook.com/sharer/sharer.php?u=' %}
-	{% set twitter = 'http://twitter.com/intent/tweet?source=webclient&text=' %}
+	{% set facebook = 'https://www.facebook.com/sharer/sharer.php?u=' %}
+	{% set twitter = 'https://twitter.com/intent/tweet?source=webclient&text=' %}
 	{% set email = 'mailto:?subject=' %}
 	{% set baseURL = url('<front>') %}
 	{% set url = baseURL|render~path|render[1:] %}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
## Jira Task
<!--- Provide a link to the Jira ticket -->
https://cm-jira.usa.gov/browse/USAGOV-1197

## Description
<!--- Summarize the changes made in this pull request, not what it's for. -->
http to https changes were reverted in [pull 872](https://github.com/usagov/usagov-2021/pull/872) by me. This changes it back. 

## Type of Changes
<!--- Put an `x` in all the boxes that apply. -->
- [ ] New Feature
- [x] Bugfix
- [ ] Frontend (Twig, Sass, JS)
  - Add screenshot showing what it should look like
- [ ] Drupal Config (requires "drush cim")
- [ ] New Modules (requires rebuild)
- [ ] Infrastructure
  - [ ] CMS
  - [ ] WAF
  - [ ] Egress
  - [ ] Tools
- [ ] Other

## Testing Instructions
<!-- This instructions are different from “testing instructions” in Jira – those are typically for Content/UX stakeholders -->
<!-- Not “see Jira” – if they are really the same, copy and paste. -->

### Requires New Config
- [ ] Yes
- [x] No

### Requires New Content
- [ ] Yes
- [x] No

### Validation Steps
- Go to any page with a share component. 
- Check that facebook & Twitter/X have https in the url 

## Security Review
<!-- Checkboxes to indicate need for review -->

- [ ] Adds/updates software (including a library or Drupal module)
- [ ] Communication with external service
- [ ] Changes permissions or workflow
- [ ] Requires SSPP updates


## Reviewer Reminders
- Reviewed code changes
- Reviewed functionality
- Security review complete or not required

## Post PR Approval Instructions
Follow these steps as soon as you merge the new changes.

1. Go to the [USAGov Circle CI project](https://app.circleci.com/pipelines/github/usagov/usagov-2021).
2. Find the commit of this pull request.
3. Build and deploy the changes.
4. Update the Jira ticket by changing the ticket status to `Review in Test` and add a comment. State whether the change is already visible on [cms-dev.usa.gov](http://cms-dev.usa.gov/) and [beta-dev.usa.gov](http://beta-dev.usa.gov/), or if the deployment is still in process.
