### PR TITLE
USAGOV-1144-slide-heights

### DIFF
--- a/web/themes/custom/usagov/scripts/carousel.js
+++ b/web/themes/custom/usagov/scripts/carousel.js
@@ -1,4 +1,3 @@
-"use strict";
 $(".slides").slick({
   "dots": true,
   "infinite": true,
@@ -46,6 +45,8 @@ $(".slides").slick({
   ],
 })
 .on("setPosition", function () {
+  "use strict";
+
   resizeSlider();
 });
 
@@ -53,6 +54,8 @@ var initSlide = getInitialSlide();
 var slickHeight = $(".slick-track").outerHeight();
 
 function resizeSlider() {
+  "use strict";
+
   $(".slick-track")
     .find(".slick-slide .usa-card")
     .css("height", slickHeight + "px");

--- a/web/themes/custom/usagov/scripts/carousel.js
+++ b/web/themes/custom/usagov/scripts/carousel.js
@@ -49,10 +49,7 @@ $(".slides").slick({
 });
 
 var initSlide = getInitialSlide();
-
 var slickHeight = $(".slick-track").outerHeight();
-
-var slideHeight = $(".slick-track").find(".slick-slide").outerHeight();
 
 function resizeSlider() {
   $(".slick-track")

--- a/web/themes/custom/usagov/scripts/carousel.js
+++ b/web/themes/custom/usagov/scripts/carousel.js
@@ -44,12 +44,22 @@ $(".slides").slick({
     },
   ],
 })
-.on('setPosition', function (event, slick) {
-    slick.$slides.css('height', slick.$slideTrack.find('.slick-slide').height() + 'px');
+.on("setPosition", function () {
+  resizeSlider();
 });
 
 var initSlide = getInitialSlide();
-console.log(`initSlide is ${initSlide}`);
+
+var slickHeight = $(".slick-track").outerHeight();
+
+var slideHeight = $(".slick-track").find(".slick-slide").outerHeight();
+
+function resizeSlider() {
+  $(".slick-track")
+    .find(".slick-slide .usa-card")
+    .css("height", slickHeight + "px");
+}
+
 $('.slides').slick('slickGoTo', initSlide);
 
 var carouselSlides = document.querySelector("#slides-list");

--- a/web/themes/custom/usagov/scripts/carousel.js
+++ b/web/themes/custom/usagov/scripts/carousel.js
@@ -1,3 +1,4 @@
+"use strict";
 $(".slides").slick({
   "dots": true,
   "infinite": true,

--- a/web/themes/custom/usagov/scripts/carousel.js
+++ b/web/themes/custom/usagov/scripts/carousel.js
@@ -43,6 +43,9 @@ $(".slides").slick({
       },
     },
   ],
+})
+.on('setPosition', function (event, slick) {
+    slick.$slides.css('height', slick.$slideTrack.find('.slick-slide').height() + 'px');
 });
 
 var initSlide = getInitialSlide();
@@ -137,7 +140,6 @@ $(".slides").on(
   "afterChange",
   function (event, slick, currentSlide) {
     "use strict";
-    console.log(`afterChange event ${currentSlide}`);
     updateSessionStorage(currentSlide);
   }
 );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
## Jira Task
<!--- Provide a link to the Jira ticket -->
https://cm-jira.usa.gov/browse/USAGOV-1144

## Description
<!--- Summarize the changes made in this pull request, not what it's for. -->
Added Javascript so slides don't jump heights 

## Type of Changes
<!--- Put an `x` in all the boxes that apply. -->
- [ ] New Feature
- [x] Bugfix
- [x] Frontend (Twig, Sass, JS)
  - Add screenshot showing what it should look like
- [ ] Drupal Config (requires "drush cim")
- [ ] New Modules (requires rebuild)
- [ ] Infrastructure
  - [ ] CMS
  - [ ] WAF
  - [ ] Egress
  - [ ] Tools
- [ ] Other

## Testing Instructions
<!-- This instructions are different from “testing instructions” in Jira – those are typically for Content/UX stakeholders -->
<!-- Not “see Jira” – if they are really the same, copy and paste. -->

### Requires New Config
- [ ] Yes
- [x] No

### Requires New Content
- [ ] Yes
- [x] No

### Validation Steps
- Clear JS Cache
- Scroll through the carousel on the homepage in desktop, tablet and mobile
- Previously the slides would lengthen / shorten by 2 pixels when last two slides were reached.
- Ensure that now slides stay the same height 

## Security Review
<!-- Checkboxes to indicate need for review -->

- [ ] Adds/updates software (including a library or Drupal module)
- [ ] Communication with external service
- [ ] Changes permissions or workflow
- [ ] Requires SSPP updates


## Reviewer Reminders
- Reviewed code changes
- Reviewed functionality
- Security review complete or not required

## Post PR Approval Instructions
Follow these steps as soon as you merge the new changes.

1. Go to the [USAGov Circle CI project](https://app.circleci.com/pipelines/github/usagov/usagov-2021).
2. Find the commit of this pull request.
3. Build and deploy the changes.
4. Update the Jira ticket by changing the ticket status to `Review in Test` and add a comment. State whether the change is already visible on [cms-dev.usa.gov](http://cms-dev.usa.gov/) and [beta-dev.usa.gov](http://beta-dev.usa.gov/), or if the deployment is still in process.
