### PR TITLE
USAGOV-1227: Fix CIS benchmark build step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -546,7 +546,6 @@ workflows:
                 - dev
                 - stage
                 - prod
-                - USAGOV-1227-fix-cis-benchmark-build-step
       - build-and-push-container:
           requires:
             - approve-build-and-push-container
@@ -556,7 +555,6 @@ workflows:
                 - dev
                 - stage
                 - prod
-                - USAGOV-1227-fix-cis-benchmark-build-step
       - approve-dev-deployment:
           type: approval
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -346,7 +346,7 @@ jobs:
           command: |
             # build a fresh docker-bench-security container
             cd /tmp/
-            git clone https://github.com/docker/docker-bench-security.git
+            git clone --depth 1 --branch v1.6.0 https://github.com/docker/docker-bench-security.git
             cd /tmp/docker-bench-security
             docker build --no-cache -t docker-bench-security .
       - run:
@@ -546,6 +546,7 @@ workflows:
                 - dev
                 - stage
                 - prod
+                - USAGOV-1227-fix-cis-benchmark-build-step
       - build-and-push-container:
           requires:
             - approve-build-and-push-container
@@ -555,6 +556,7 @@ workflows:
                 - dev
                 - stage
                 - prod
+                - USAGOV-1227-fix-cis-benchmark-build-step
       - approve-dev-deployment:
           type: approval
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -234,7 +234,7 @@ jobs:
           command: |
             # build a fresh docker-bench-security container
             cd /tmp/
-            git clone https://github.com/docker/docker-bench-security.git
+            git clone --depth 1 --branch v1.6.0 https://github.com/docker/docker-bench-security.git
             cd /tmp/docker-bench-security
             docker build --no-cache -t docker-bench-security .
             # use the fresh container to scan


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
## Jira Task
<!--- Provide a link to the Jira ticket -->
https://cm-jira.usa.gov/browse/USAGOV-1227

## Description
<!--- Summarize the changes made in this pull request, not what it's for. -->
The latest docker-bench-security code is hitting an error. This explicitly specifies the v1.6.0 tag, so we get the code that was working for us last week. 

## Type of Changes
<!--- Put an `x` in all the boxes that apply. -->
- [ ] New Feature
- [x] Bugfix
- [ ] Frontend (Twig, Sass, JS)
  - Add screenshot showing what it should look like
- [ ] Drupal Config (requires "drush cim")
- [ ] New Modules (requires rebuild)
- [ ] Infrastructure
  - [ ] CMS
  - [ ] WAF
  - [ ] Egress
  - [ ] Tools
- [ ] Other

## Testing Instructions
See successful build here: https://app.circleci.com/pipelines/github/usagov/usagov-2021/7206/workflows/c2215fbf-7fa4-4091-9846-0783182734c8/jobs/14875
"Create Container for CIS Benchmarks" is the step that changed. 

### Requires New Config
- [ ] Yes
- [x] No

### Requires New Content
- [ ] Yes
- [x] No

### Validation Steps
N/A.

## Security Review
<!-- Checkboxes to indicate need for review -->

- [ ] Adds/updates software (including a library or Drupal module)
- [ ] Communication with external service
- [ ] Changes permissions or workflow
- [ ] Requires SSPP updates


## Reviewer Reminders
- Reviewed code changes
- Reviewed functionality
- Security review complete or not required

## Post PR Approval Instructions
Follow these steps as soon as you merge the new changes.

1. Go to the [USAGov Circle CI project](https://app.circleci.com/pipelines/github/usagov/usagov-2021).
2. Find the commit of this pull request.
3. Build and deploy the changes.
4. Update the Jira ticket by changing the ticket status to `Review in Test` and add a comment. State whether the change is already visible on [cms-dev.usa.gov](http://cms-dev.usa.gov/) and [beta-dev.usa.gov](http://beta-dev.usa.gov/), or if the deployment is still in process.
