### PR TITLE
USAGOV-1266: remove rate limit config -- hot patch for STAGE

### DIFF
--- a/.docker/src-cms/etc/nginx/partials/cms.conf.tmpl
+++ b/.docker/src-cms/etc/nginx/partials/cms.conf.tmpl
@@ -1,15 +1,8 @@
 
 # underscore catch-all allows this to work on local dockers because who knows what hostname local devs have setup
 
-# NGINX Rate limiting configuration
-limit_req_zone $binary_remote_addr zone=limitcmsbyaddr:10m rate=10r/s;
-limit_req_status 429;
-
 server {
     listen 80 default_server;
-
-    # We are limiting 150 requests per IP address per second
-    limit_req zone=limitcmsbyaddr burst=150 nodelay;
 
     server_name ${CMS_HOST} _;
 

--- a/.docker/src-waf/etc/nginx/conf.d/default.conf
+++ b/.docker/src-waf/etc/nginx/conf.d/default.conf
@@ -3,15 +3,8 @@ map $http_upgrade $connection_upgrade {
     '' close;
 }
 
-# NGINX Rate limiting configuration
-limit_req_zone $binary_remote_addr zone=limitwafbyaddr:10m rate=10r/s;
-limit_req_status 429;
-
 server {
     listen 80;
-
-    # We are limiting 55 requests per IP address per second
-    limit_req zone=limitwafbyaddr burst=55 nodelay;
 
     server_name _;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
## Jira Task
<!--- Provide a link to the Jira ticket -->
https://cm-jira.usa.gov/browse/USAGOV-1266

## Description
<!--- Summarize the changes made in this pull request, not what it's for. -->
Remove all nginx rate limit settings.

## Type of Changes
<!--- Put an `x` in all the boxes that apply. -->
- [ ] New Feature
- [x] Bugfix
- [ ] Frontend (Twig, Sass, JS)
  - Add screenshot showing what it should look like
- [ ] Drupal Config (requires "drush cim")
- [ ] New Modules (requires rebuild)
- [x] Infrastructure
  - [x] CMS
  - [x] WAF
  - [ ] Egress
  - [ ] Tools
- [ ] Other

## Testing Instructions
<!-- This instructions are different from “testing instructions” in Jira – those are typically for Content/UX stakeholders -->
<!-- Not “see Jira” – if they are really the same, copy and paste. -->
- On the home page, perform two or more hard resets in a row. Check that there are no 429 errors in the console.

### Requires New Config
- [ ] Yes
- [x] No

### Requires New Content
- [ ] Yes
- [x] No

### Validation Steps

## Security Review
<!-- Checkboxes to indicate need for review -->

- [ ] Adds/updates software (including a library or Drupal module)
- [ ] Communication with external service
- [ ] Changes permissions or workflow
- [ ] Requires SSPP updates


## Reviewer Reminders
- Reviewed code changes
- Reviewed functionality
- Security review complete or not required

## Post PR Approval Instructions
Follow these steps as soon as you merge the new changes.

1. Go to the [USAGov Circle CI project](https://app.circleci.com/pipelines/github/usagov/usagov-2021).
2. Find the commit of this pull request.
3. Build and deploy the changes.
4. Update the Jira ticket by changing the ticket status to `Review in Test` and add a comment. State whether the change is already visible on [cms-dev.usa.gov](http://cms-dev.usa.gov/) and [beta-dev.usa.gov](http://beta-dev.usa.gov/), or if the deployment is still in process.
