### PR TITLE
USAGOV-1278 adding FAQ schema causes error on some pages

### DIFF
--- a/web/themes/custom/usagov/sass/USWDS_CKEditor_Custom_Styles.scss
+++ b/web/themes/custom/usagov/sass/USWDS_CKEditor_Custom_Styles.scss
@@ -42,3 +42,11 @@ html div.usa-accordion--bordered .usa-accordion__content {
   border-right: 0.25rem solid #f0f0f0!important;
   padding-bottom: 1rem!important;
 }
+
+.cke_widget_element.embedded-entity:empty:before {
+  content:'There is a hidden component on this page. To remove it, right-click this red box and select "cut."';
+  display:block;
+  padding: 3px;
+  background-color:lightsalmon;
+  margin:1em 0;
+}

--- a/web/themes/custom/usagov/usagov.theme
+++ b/web/themes/custom/usagov/usagov.theme
@@ -148,7 +148,7 @@ function faq_process_components(&$dom) {
     $component = $embedded_paragraph->get('paragraph')[0]->entity;
 
     // Process component by its type
-    if($component == NULL){
+    if ($component == NULL) {
       // No entity exists for this paragraph component. It is probably a reference to a deleted component.
       // Remove the element and move on.
       $element->parentNode->removeChild($element);

--- a/web/themes/custom/usagov/usagov.theme
+++ b/web/themes/custom/usagov/usagov.theme
@@ -72,6 +72,10 @@ function generate_faq(&$node) {
         $answer->loadHTML('<?xml encoding="UTF-8"><html><body></body></html>');
 
       }
+      elseif ($element->nodeName == "drupal-paragraph") {
+        // $element is a paragraph component that should not be displayed
+        // Skip it
+      }
       elseif ($element->nodeName == "#text") {
         // $element is a text node
         // This is white space that we can ignore.
@@ -144,6 +148,12 @@ function faq_process_components(&$dom) {
     $component = $embedded_paragraph->get('paragraph')[0]->entity;
 
     // Process component by its type
+    if($component == NULL){
+      // No entity exists for this paragraph component. It is probably a reference to a deleted component.
+      // Remove the element and move on.
+      $element->parentNode->removeChild($element);
+      break;
+    }
     $componentType = $component->getType();
     if ($componentType == "uswds_accordion") {
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
## Jira Task
<!--- Provide a link to the Jira ticket -->
https://cm-jira.usa.gov/browse/USAGOV-1278

## Description
<!--- Summarize the changes made in this pull request, not what it's for. -->
* Detect when there is no entity for the referenced paragraph component, and skip that element.
  * Also, do not display <drupal-paragraph> elements in FAQ schema.
* CSS within CKEditor that highlights empty paragraph components.
  * Provides helpful instruction explaining what it is and how to remove it.

## Type of Changes
<!--- Put an `x` in all the boxes that apply. -->
- [ ] New Feature
- [x] Bugfix
- [x] Frontend (Twig, Sass, JS)
  - Add screenshot showing what it should look like
- [ ] Drupal Config (requires "drush cim")
- [ ] New Modules (requires rebuild)
- [ ] Infrastructure
  - [ ] CMS
  - [ ] WAF
  - [ ] Egress
  - [ ] Tools
- [ ] Other

## Testing Instructions
<!-- This instructions are different from “testing instructions” in Jira – those are typically for Content/UX stakeholders -->
<!-- Not “see Jira” – if they are really the same, copy and paste. -->

**I know this is a lot of weird steps, so feel free to ping me if anything is unclear**

* Visit `/es/solicitar-pasaporte-estadounidense-primera-vez` or `/es/ayuda-hipoteca-desastre` OR
  * Edit any page
  * Within CKEditor, add any USWDS paragraph component
  * Edit the component
  * Click the 3-dot icon, and select "Remove" until there is nothing left inside the component
  * Click "Update"
* Confirm that the CKEditor includes a red box in the location of the hidden component
* Confirm that the red box says `There is a hidden component on this page. To remove it, right-click this red box and select "cut."`
* Check the box for "FAQ Page"
* Save and view the page
* Confirm that the page loads without an error
* Inspect the DOM to confirm that you can find the hidden component
  * It will be an empty div with attributes like this: ```<div data-embed-button="paragraphs" data-entity-label="USWDS Components" data-paragraph-id="f6f6bd7f-962a-40c4-8f74-fa896fdfe2ef" data-langcode="es" data-view-mode="embed" data-entity-embed-display="entity_reference_revisions:entity_reference_revisions_entity_view" data-entity-type="embedded_paragraphs" data-entity-uuid="f6f6bd7f-962a-40c4-8f74-fa896fdfe2ef" data-entity-embed-display-settings="[]" class="embedded-entity"></div>```
* Inspect the DOM to confirm that the `FAQPage` schema does not contain the <drupal-paragraph> element
* Edit the page
* Right-click the red box and select "cut"
* The red box should disappear
* Save and view the page again
* Inspect the DOM to confirm that the hidden component is gone


### Requires New Config
- [ ] Yes
- [ ] No

### Requires New Content
- [ ] Yes
- [ ] No

### Validation Steps
- Test instruction 1
- Test instruction 2
- Test instruction 3

## Security Review
<!-- Checkboxes to indicate need for review -->

- [ ] Adds/updates software (including a library or Drupal module)
- [ ] Communication with external service
- [ ] Changes permissions or workflow
- [ ] Requires SSPP updates


## Reviewer Reminders
- Reviewed code changes
- Reviewed functionality
- Security review complete or not required

## Post PR Approval Instructions
Follow these steps as soon as you merge the new changes.

1. Go to the [USAGov Circle CI project](https://app.circleci.com/pipelines/github/usagov/usagov-2021).
2. Find the commit of this pull request.
3. Build and deploy the changes.
4. Update the Jira ticket by changing the ticket status to `Review in Test` and add a comment. State whether the change is already visible on [cms-dev.usa.gov](http://cms-dev.usa.gov/) and [beta-dev.usa.gov](http://beta-dev.usa.gov/), or if the deployment is still in process.
