### PR TITLE
usagov-1274-nav-cards-background-color: New background gray color for…

### DIFF
--- a/web/themes/custom/usagov/sass/_usagov-variables.scss
+++ b/web/themes/custom/usagov/sass/_usagov-variables.scss
@@ -23,6 +23,7 @@ $light-blue: #e5f8fd;
 $pale-blue: #e7f6f8;
 $light-gray: #f3f3f3;
 $gray: #dfe1e2;
+$usagov-gray: #f0f0f0;
 $medium-gray: #e7e7e7;
 $deep-gray: #707070;
 $dark-gray: #4b4b4d;
@@ -66,7 +67,7 @@ $card: (
   border-color: $cyan-50v,
   hover-background-color: $cyan-light,
   hover-border-color: $cyan-50v,
-  group-background-color: $light-gray,
+  group-background-color: $usagov-gray,
   text-color: $black,
   background-color: $light-blue,
 );


### PR DESCRIPTION
… cards

<!--- Provide a general summary of your changes in the title above -->
## Jira Task
<!--- Provide a link to the Jira ticket -->
https://cm-jira.usa.gov/browse/USAGOV-1274

## Description
<!--- Summarize the changes made in this pull request, not what it's for. -->
Changed the background color from #f3f3f3 to #f0f0f0 for the navigation cards. 

## Type of Changes
<!--- Put an `x` in all the boxes that apply. -->
- [ ] New Feature
- [ ] Bugfix
- [x] Frontend (Twig, Sass, JS)
  - Add screenshot showing what it should look like
- [ ] Drupal Config (requires "drush cim")
- [ ] New Modules (requires rebuild)
- [ ] Infrastructure
  - [ ] CMS
  - [ ] WAF
  - [ ] Egress
  - [ ] Tools
- [ ] Other

## Testing Instructions
<!-- This instructions are different from “testing instructions” in Jira – those are typically for Content/UX stakeholders -->
<!-- Not “see Jira” – if they are really the same, copy and paste. -->

### Requires New Config
- [ ] Yes
- [x] No

### Requires New Content
- [ ] Yes
- [x] No

### Validation Steps
- Check on a navigation card page (i.e /travel) that the background color (class="usagov-cards") is the new correct gray #f0f0f0

## Security Review
<!-- Checkboxes to indicate need for review -->

- [ ] Adds/updates software (including a library or Drupal module)
- [ ] Communication with external service
- [ ] Changes permissions or workflow
- [ ] Requires SSPP updates


## Reviewer Reminders
- Reviewed code changes
- Reviewed functionality
- Security review complete or not required

## Post PR Approval Instructions
Follow these steps as soon as you merge the new changes.

1. Go to the [USAGov Circle CI project](https://app.circleci.com/pipelines/github/usagov/usagov-2021).
2. Find the commit of this pull request.
3. Build and deploy the changes.
4. Update the Jira ticket by changing the ticket status to `Review in Test` and add a comment. State whether the change is already visible on [cms-dev.usa.gov](http://cms-dev.usa.gov/) and [beta-dev.usa.gov](http://beta-dev.usa.gov/), or if the deployment is still in process.
