### PR TITLE
USAGOV-1390: Preserve closing tags in quoted html within script elements

### DIFF
--- a/web/modules/custom/usagov_ssg_postprocessing/src/EventSubscriber/PagerPathSubscriber.php
+++ b/web/modules/custom/usagov_ssg_postprocessing/src/EventSubscriber/PagerPathSubscriber.php
@@ -38,8 +38,11 @@ class PagerPathSubscriber implements EventSubscriberInterface {
   public function modifyHtml(ModifyHtmlEvent $event) {
     $html = $event->getHtml();
     $path = $event->getPath();
+
+    // LIBXML_SCHEMA_CREATE fixes a problem wherein DOMDocument would remove closing HTML
+    // tags within quoted text in a script element. See https://bugs.php.net/bug.php?id=74628
     $document = new \DOMDocument();
-    @$document->loadHTML($html);
+    @$document->loadHTML($html, LIBXML_SCHEMA_CREATE);
     $xpath = new \DOMXPath($document);
     /** @var \DOMElement $node */
     foreach ($xpath->query('//a[(contains(@href,"?letter=") or contains(@href,"&letter="))]') as $node) {

--- a/web/modules/custom/usagov_ssg_postprocessing/src/EventSubscriber/TomeEventSubscriber.php
+++ b/web/modules/custom/usagov_ssg_postprocessing/src/EventSubscriber/TomeEventSubscriber.php
@@ -132,8 +132,11 @@ class TomeEventSubscriber implements EventSubscriberInterface {
    */
   public function modifyHtml(ModifyHtmlEvent $event) {
     $html = $event->getHtml();
+
+    // LIBXML_SCHEMA_CREATE fixes a problem wherein DOMDocument would remove closing HTML
+    // tags within quoted text in a script element. See https://bugs.php.net/bug.php?id=74628
     $document = new \DOMDocument();
-    @$document->loadHTML($html);
+    @$document->loadHTML($html, LIBXML_SCHEMA_CREATE);
     $xpath = new \DOMXPath($document);
     $changes = FALSE;
     /** @var \DOMElement $node */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
## Jira Task
<!--- Provide a link to the Jira ticket -->
https://cm-jira.usa.gov/browse/USAGOV-1390

## Description
<!--- Summarize the changes made in this pull request, not what it's for. -->
Added LIBXML_SCHEMA_CREATE to two calls to DOMDocument::loadHTML. 

## Type of Changes
<!--- Put an `x` in all the boxes that apply. -->
- [ ] New Feature
- [x] Bugfix
- [ ] Frontend (Twig, Sass, JS)
  - Add screenshot showing what it should look like
- [ ] Drupal Config (requires "drush cim")
- [ ] New Modules (requires rebuild)
- [ ] Infrastructure
  - [ ] CMS
  - [ ] WAF
  - [ ] Egress
  - [ ] Tools
- [ ] Other

## Testing Instructions
<!-- This instructions are different from “testing instructions” in Jira – those are typically for Content/UX stakeholders -->
<!-- Not “see Jira” – if they are really the same, copy and paste. -->
This fixes a problem where the HTML output by the static site generator would lose closing HTML tags that were in quoted HTML within <script> elements -- specifically, within "FAQPage" schema sections. So, to do this, you will need to run the static site generator. 

### Requires New Config
- [ ] Yes
- [x] No

### Requires New Content
- [ ] Yes
- [x] No

### Validation Steps
- Open an ssh session into your cms container: `bin/ssh` or whatever you do. 
- In that session, run `./scripts/tome-static.sh`
- Wait about 20 minutes. Sorry!
- When the process completes, inspect the results in your `html` directory. I recommend you spot-check a particular page.
    - Compare the source of these two pages to see the problem. Look for "FAQPage" and examine the HTML embedded in that stucture; on the www version all the closing tags are missing: 
        - https://cms.usa.gov/es/ayuda-abuso-alcohol-drogas
        - https://www.usa.gov/es/ayuda-abuso-alcohol-drogas 
    - Compare the same page locally to see that it's fixed: 
        -  http://localhost/es/ayuda-abuso-alcohol-drogas
        - file: html/es/ayuda-abuso-alcohol-drogas/index.html

(I did a more thorough scan of all the files, comparing a diff between them, to see whether other parts of pages were affected. That meant running the static site generator twice. I'm not asking you to do that.) 

## Security Review
<!-- Checkboxes to indicate need for review -->

- [ ] Adds/updates software (including a library or Drupal module)
- [ ] Communication with external service
- [ ] Changes permissions or workflow
- [ ] Requires SSPP updates


## Reviewer Reminders
- Reviewed code changes
- Reviewed functionality
- Security review complete or not required

## Post PR Approval Instructions
Follow these steps as soon as you merge the new changes.

1. Go to the [USAGov Circle CI project](https://app.circleci.com/pipelines/github/usagov/usagov-2021).
2. Find the commit of this pull request.
3. Build and deploy the changes.
4. Update the Jira ticket by changing the ticket status to `Review in Test` and add a comment. State whether the change is already visible on [cms-dev.usa.gov](http://cms-dev.usa.gov/) and [beta-dev.usa.gov](http://beta-dev.usa.gov/), or if the deployment is still in process.
