### PR TITLE
USAGOV-1316-attribute-not-allowed-on-li: Changed list element to div

### DIFF
--- a/web/themes/custom/usagov/sass/_header.scss
+++ b/web/themes/custom/usagov/sass/_header.scss
@@ -106,7 +106,7 @@
   }
 }
 
-.usa-header--extended div.language-switcher-language-url ul.links {
+.usa-header--extended div.language-switcher-language-url div.links {
   display: flex;
   justify-content: flex-end;
   margin-top: 0.3rem;

--- a/web/themes/custom/usagov/sass/mobile-menu.scss
+++ b/web/themes/custom/usagov/sass/mobile-menu.scss
@@ -146,7 +146,7 @@ ul.navigation__items {
     display: flex;
   }
 
-  .usa-header--extended div.language-switcher-language-url ul.links {
+  .usa-header--extended div.language-switcher-language-url div.links {
     position: absolute;
     display: block;
     width: auto;

--- a/web/themes/custom/usagov/templates/block--languageswitcher.html.twig
+++ b/web/themes/custom/usagov/templates/block--languageswitcher.html.twig
@@ -51,15 +51,15 @@
               {% set toggle_url = current_language == 'es' ? '/' : '/es' %}
             {% endif %}
 
-            <ul class="links usa-nav__primary usa-accordion">
-                <li hreflang="{{ other_language }}" class="usa-nav__primary-item">
+            <div class="links usa-nav__primary usa-accordion">
+                <div hreflang="{{ other_language }}" class="usa-nav__primary-item">
                     <a href="{{ toggle_url }}" class="language-link" hreflang="{{ other_language }}">{{ current_language == 'es' ? 'English' : 'Español' }}</a>
-                </li>
-            </ul>
+                </div>
+            </div>
         {% else %}
             {# if language_toggle is not set, then the default language_switcher content is used #}
             {{ content }}
         {% endif %}
-  
+
     {% endblock %}
   </div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
## Jira Task
<!--- Provide a link to the Jira ticket -->
https://cm-jira.usa.gov/browse/USAGOV-1316

## Description
<!--- Summarize the changes made in this pull request, not what it's for. -->

## Type of Changes
<!--- Put an `x` in all the boxes that apply. -->
- [ ] New Feature
- [x] Bugfix
- [ ] Frontend (Twig, Sass, JS)
  - Add screenshot showing what it should look like
- [ ] Drupal Config (requires "drush cim")
- [ ] New Modules (requires rebuild)
- [ ] Infrastructure
  - [ ] CMS
  - [ ] WAF
  - [ ] Egress
  - [ ] Tools
- [x] Other:a11y

## Testing Instructions
<!-- This instructions are different from “testing instructions” in Jira – those are typically for Content/UX stakeholders -->
<!-- Not “see Jira” – if they are really the same, copy and paste. -->

### Requires New Config
- [ ] Yes
- [x] No

### Requires New Content
- [ ] Yes
- [x] No

### Validation Steps
- On any page refresh cache
- Nothing visually should have changed
- Inspect the language toggle button
- It should now be a div in a div instead of an unordered list with just one item. 

## Security Review
<!-- Checkboxes to indicate need for review -->

- [ ] Adds/updates software (including a library or Drupal module)
- [ ] Communication with external service
- [ ] Changes permissions or workflow
- [ ] Requires SSPP updates


## Reviewer Reminders
- Reviewed code changes
- Reviewed functionality
- Security review complete or not required

## Post PR Approval Instructions
Follow these steps as soon as you merge the new changes.

1. Go to the [USAGov Circle CI project](https://app.circleci.com/pipelines/github/usagov/usagov-2021).
2. Find the commit of this pull request.
3. Build and deploy the changes.
4. Update the Jira ticket by changing the ticket status to `Review in Test` and add a comment. State whether the change is already visible on [cms-dev.usa.gov](http://cms-dev.usa.gov/) and [beta-dev.usa.gov](http://beta-dev.usa.gov/), or if the deployment is still in process.
