### PR TITLE
USAGOV-1268-warning-from-usa-twig-vars: change in_arry to array_key_e…

### DIFF
--- a/web/modules/custom/usa_twig_vars/usa_twig_vars.module
+++ b/web/modules/custom/usa_twig_vars/usa_twig_vars.module
@@ -274,7 +274,8 @@ function usa_twig_vars_form_alter(&$form, &$form_state, $form_id) {
  */
 function usa_twig_vars_after_build($form, &$form_state) {
   // Unchecks Generate automatic URL alias if path exists, if NOT home page
-  if (in_array('field_page_type', $form_state->getValues())) {
+  //in_array returns true unless strict mode is turned on but strict mode returns false on other pages where the key is found
+  if (array_key_exists('field_page_type', $form_state->getValues())) {
     $page_type = NULL;
     if (is_array($form_state->getValues()['field_page_type'])) {
       $page_type = $form_state->getValues()['field_page_type'][0];


### PR DESCRIPTION
…xists function

<!--- Provide a general summary of your changes in the title above -->
## Jira Task
<!--- Provide a link to the Jira ticket -->
https://cm-jira.usa.gov/browse/USAGOV-1268

## Description
<!--- Summarize the changes made in this pull request, not what it's for. -->
Remove the warning from admin pages

## Type of Changes
<!--- Put an `x` in all the boxes that apply. -->
- [ ] New Feature
- [x] Bugfix
- [ ] Frontend (Twig, Sass, JS)
  - Add screenshot showing what it should look like
- [ ] Drupal Config (requires "drush cim")
- [ ] New Modules (requires rebuild)
- [ ] Infrastructure
  - [ ] CMS
  - [ ] WAF
  - [ ] Egress
  - [ ] Tools
- [ ] Other

## Testing Instructions
<!-- This instructions are different from “testing instructions” in Jira – those are typically for Content/UX stakeholders -->
<!-- Not “see Jira” – if they are really the same, copy and paste. -->

### Requires New Config
- [ ] Yes
- [x] No

### Requires New Content
- [ ] Yes
- [x] No

### Validation Steps
- Have your cms logs next to your localhost 
- Check that when you go to /admin/content the ""Warning: Undefined array key "field_page_type" in usa_twig_vars_after_build() ..." is no longer present
- Check that it is not present on other admin pages as well
- This function makes it so that a url alias does not have to be provided for the homepage
- Check a non-hompage content page and click edit
-- You should see  the url alias field is required. Make a change and make sure that is working as expected. (change content and try to save with and without an alias etc) 
![Screenshot 2024-03-25 at 11 00 43 AM](https://github.com/usagov/usagov-2021/assets/108532577/b394cc92-0fb8-4b0a-97c5-2600e3a401f7)
- Check the homepage and click edit
-- You should see that the url field is **not** required. Make a change and make sure that is working as expected. (change content and try to save with and without an alias etc) 
![Screenshot 2024-03-25 at 11 02 02 AM](https://github.com/usagov/usagov-2021/assets/108532577/4d5dd9b5-e0f6-42e2-a169-7c98b573bca0)

## Security Review
<!-- Checkboxes to indicate need for review -->

- [ ] Adds/updates software (including a library or Drupal module)
- [ ] Communication with external service
- [ ] Changes permissions or workflow
- [ ] Requires SSPP updates


## Reviewer Reminders
- Reviewed code changes
- Reviewed functionality
- Security review complete or not required

## Post PR Approval Instructions
Follow these steps as soon as you merge the new changes.

1. Go to the [USAGov Circle CI project](https://app.circleci.com/pipelines/github/usagov/usagov-2021).
2. Find the commit of this pull request.
3. Build and deploy the changes.
4. Update the Jira ticket by changing the ticket status to `Review in Test` and add a comment. State whether the change is already visible on [cms-dev.usa.gov](http://cms-dev.usa.gov/) and [beta-dev.usa.gov](http://beta-dev.usa.gov/), or if the deployment is still in process.
