### PR TITLE
USAGOV-1572: Correct the loop that expands synonyms in usagov_directories_views_pre_render

### DIFF
--- a/web/modules/custom/usagov_directories/usagov_directories.module
+++ b/web/modules/custom/usagov_directories/usagov_directories.module
@@ -46,7 +46,8 @@ function usagov_directories_views_pre_render($view) {
   if ($view->id() == 'federal_agencies' && ($view->current_display == 'block_1' || $view->current_display == "block_2")) {
 
     $new_result = $view->result;
-    for ($res = 0; $res < count($new_result); $res++) {
+    $num_results = count($new_result);
+    for ($res = 0; $res < $num_results; $res++) {
       $nid = $new_result[$res]->_entity->nid[0]->value;
       $node = Node::load($nid);
       $node_title = $node->get('title')[0]->value;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
## Jira Task
<!--- Provide a link to the Jira ticket -->
https://cm-jira.usa.gov/browse/USAGOV-1572

## Description
<!--- Summarize the changes made in this pull request, not what it's for. -->
Corrected the end condition for the "for" loop that iterates through the entries on a federal directories view page. When  the list contained one or more "synonym" entries that didn't have valid targets, the last entries in the list would be skipped, because this loop dynamically checked the length of the list for its termination condition. 

So for example, if we start with 12 entries, we need to check 12 entries even if we delete a few in the middle in the process. 

## Type of Changes
<!--- Put an `x` in all the boxes that apply. -->
- [ ] New Feature
- [x] Bugfix
- [ ] Frontend (Twig, Sass, JS)
  - Add screenshot showing what it should look like
- [ ] Drupal Config (requires "drush cim")
- [ ] New Modules (requires rebuild)
- [ ] Infrastructure
  - [ ] CMS
  - [ ] WAF
  - [ ] Egress
  - [ ] Tools
- [ ] Other

## Testing Instructions
<!-- This instructions are different from “testing instructions” in Jira – those are typically for Content/UX stakeholders -->
<!-- Not “see Jira” – if they are really the same, copy and paste. -->

### Requires New Config
- [ ] Yes
- [x] No

### Requires New Content
- [ ] Yes
- [x] No

### Validation Steps
Note: you need to clear your render cache after switching to this branch, at least if you've loaded the federal agencies views before. 

To create a situation that failed with the current code and works with the new code, you need a Federal Directory Synonym that points to a Directory Record that no longer exists, and you need another Federal Directory Synonym that starts with the same letter and will come last on its page in the A-Z index. If you load the production database backup USAGOV-1555.prod.9243.post-deploy.sql you will get this! The synonym that points to a deleted record is "Amtrak" and the last entry at /agency-index (the "A" page) is "Arthritis, Musculoskeletal and Skin Diseases, National Institute of"

Without this fix, that last entry will have no details when you expand it, and the link will go to a /node/ path. With this fix, it will work correctly. 

If you don't want to blow away your database and you don't have this situation already, you can create it! Make a Directory Record (name doesn't matter), and make an "AAA" synonym pointing to it, then delete the Directory Record. Then, if the last entry on the "A" page isn't a synonym, make an "Az" synonym and point it at a real Directory Record. 

(This applies to any page; I just use "A" as an example.) 


## Security Review
<!-- Checkboxes to indicate need for review -->

- [ ] Adds/updates software (including a library or Drupal module)
- [ ] Communication with external service
- [ ] Changes permissions or workflow
- [ ] Requires SSPP updates


## Reviewer Reminders
- Reviewed code changes
- Reviewed functionality
- Security review complete or not required

## Post PR Approval Instructions
Follow these steps as soon as you merge the new changes.

1. Go to the [USAGov Circle CI project](https://app.circleci.com/pipelines/github/usagov/usagov-2021).
2. Find the commit of this pull request.
3. Build and deploy the changes.
4. Update the Jira ticket by changing the ticket status to `Review in Test` and add a comment. State whether the change is already visible on [cms-dev.usa.gov](http://cms-dev.usa.gov/) and [beta-dev.usa.gov](http://beta-dev.usa.gov/), or if the deployment is still in process.
