### PR TITLE
USAGOV-1156: Change hook and rename variables

### DIFF
--- a/web/modules/custom/usa_twig_vars/usa_twig_vars.module
+++ b/web/modules/custom/usa_twig_vars/usa_twig_vars.module
@@ -353,7 +353,7 @@ function usa_twig_vars_after_build($form, &$form_state) {
 /** Helper function to check if node should be excluded from contact center based on path. Updates the exclude from url checkbox on edit pages.  */
 function usa_twig_vars_check_exclude_from_contact_center($node_to_check) {
   $path_alias_to_check = $node_to_check->toUrl()->toString();
-  if (str_contains($path_alias_to_check, '/es/articulos/') || str_contains($path_alias_to_check, '/features/')) {
+  if (str_starts_with($path_alias_to_check, '/es/articulos/') || str_starts_with($path_alias_to_check, '/features/')) {
     $node_to_check->set('field_exclude_from_contact_cente', 1);
     $node_to_check->save();
   }

--- a/web/modules/custom/usa_twig_vars/usa_twig_vars.module
+++ b/web/modules/custom/usa_twig_vars/usa_twig_vars.module
@@ -351,22 +351,18 @@ function usa_twig_vars_after_build($form, &$form_state) {
 }
 
 /** Helper function to check if node should be excluded from contact center based on path. Updates the exclude from url checkbox on edit pages.  */
-function usa_twig_vars_check_exclude_from_contact_center($nodeToCheck) {
-  $pathAliasToCheck = $nodeToCheck->toUrl()->toString();
-  if (str_contains($pathAliasToCheck, '/es/articulos/') || str_contains($pathAliasToCheck, '/features/')) {
-    $old_checkbox = $nodeToCheck->get('field_exclude_from_contact_cente')[0]->value;
-
-    $nodeToCheck->set('field_exclude_from_contact_cente', 1);
-    $nodeToCheck->save();
-
-    $new_checkbox = $nodeToCheck->get('field_exclude_from_contact_cente')[0]->value;
+function usa_twig_vars_check_exclude_from_contact_center($node_to_check) {
+  $path_alias_to_check = $node_to_check->toUrl()->toString();
+  if (str_contains($path_alias_to_check, '/es/articulos/') || str_contains($path_alias_to_check, '/features/')) {
+    $node_to_check->set('field_exclude_from_contact_cente', 1);
+    $node_to_check->save();
   }
 }
 
 /** Helper function to get the node from a path. Used in path_alias_insert and path_alias_update.  */
 function usa_twig_vars_get_node_from_path($path) {
-  $path_alias = $path->getAlias();
-  $params = Url::fromUserInput($path_alias)->getRouteParameters();
+  $path_alias_url = $path->getAlias();
+  $params = Url::fromUserInput($path_alias_url)->getRouteParameters();
   $entity_type_id = array_key_first($params);
   $node = \Drupal::entityTypeManager()->getStorage($entity_type_id)->load($params[$entity_type_id]);
   return $node;
@@ -399,10 +395,9 @@ function usa_twig_vars_path_alias_update(PathAliasInterface $path) {
 }
 
 /**
- * Implements hook_path_alias_insert()
+ * Implements hook_node_insert()
  * When a user creates a new content page this is triggered to see if the node should be excluded from the contact center. If so the value of the exclude from contact center is set to 1.
  */
-function usa_twig_vars_path_alias_insert(PathAliasInterface $path) {
-  $node = usa_twig_vars_get_node_from_path($path);
-  usa_twig_vars_check_exclude_from_contact_center($node);
+function usa_twig_vars_node_insert(NodeInterface $node_to_check) {
+  usa_twig_vars_check_exclude_from_contact_center($node_to_check);
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
## Jira Task
<!--- Provide a link to the Jira ticket -->
https://cm-jira.usa.gov/browse/USAGOV-1156

## Description
<!--- Summarize the changes made in this pull request, not what it's for. -->
This PR should implement two actions. 

1) Automatic Exclusion From Contact Center (EFCC): 
When a url alias is updated to include '/features/' or '/articulos' the checkbox (value) for EFCC should be updated to checked (1). To verify one needs to save the node and go back into edit to view that the checkbox is in fact checked. **_Note_**: Removing '/features/' or '/articulos' from the url alias does not automatically uncheck the EFCC as some pages are also excluded that are not features. 

2) Batch exclusion of features: 
A new features view (http://localhost/admin/structure/views/view/features) is created that upon execution (loading and seeing the view) updates all feature articles in English and Spanish. A link to this view is included in the USAGov tools menu. 

## Type of Changes
<!--- Put an `x` in all the boxes that apply. -->
- [x] New Feature
- [ ] Bugfix
- [ ] Frontend (Twig, Sass, JS)
  - Add screenshot showing what it should look like
- [x] Drupal Config (requires "drush cim")
- [ ] New Modules (requires rebuild)
- [ ] Infrastructure
  - [ ] CMS
  - [ ] WAF
  - [ ] Egress
  - [ ] Tools
- [ ] Other

## Testing Instructions
<!-- This instructions are different from “testing instructions” in Jira – those are typically for Content/UX stakeholders -->
<!-- Not “see Jira” – if they are really the same, copy and paste. -->

### Requires New Config
- [x] Yes
- [ ] No

### Requires New Content
- [ ] Yes
- [x] No

### Validation Steps
#1 is the bug fix but please test #2 and #3 too 
**1) Automatic Exclusion From Contact Center (EFCC):** 
When a url alias is updated to include '/features/' or '/articulos' the checkbox (value) for EFCC should be updated to checked (1). To verify:
- Create a new node 
- Include a url alias with /features/ prepended (i.e  /features/travel or /features/currency etc) 
- Save the node
- Verify the path is correct (before it was changing to the title)
- Go back to node edit 
- Verify that the EFCC checkbox is checked. 
- Remove the /features/ prepended url 
- Save the node
- Go back to node edit 
- Verify that the EFCC checkbox is still checked (should not remove the check, unchecking should only happen manually) 
- Repeat for a Spanish node with  '/articulos' 

**2) Automatic Exclusion From Contact Center (EFCC):** 
When a url alias is updated to include '/features/' or '/articulos' the checkbox (value) for EFCC should be updated to checked (1). To verify:
- Select a non-feature node (i.e /travel or /currency etc) 
- Update it's url alias to include /features/ prepended (i.e  /features/travel or /features/currency etc) 
- Save the node
- Go back to node edit 
- Verify that the EFCC checkbox is checked. 
- Remove the /features/ prepended url 
- Save the node
- Go back to node edit 
- Verify that the EFCC checkbox is still checked (should not remove the check, unchecking should only happen manually) 
- Repeat for a Spanish node with  '/articulos' 

**3) Batch exclusion of features:** 
A new features view (http://localhost/admin/structure/views/view/features) is created that upon execution (loading and seeing the view) updates all feature articles in English and Spanish. A link to this view is included in the USAGov tools menu. 
- Review the current list of features included below. Select nodes on your local that currently have EFCC unchecked (recommend looking incase any data is different on your computer) 
- Either navigate to  http://localhost/admin/structure/views/view/features or use the menu link (image below) to get to the view 
![Screenshot 2024-06-20 at 8 08 56 AM](https://github.com/usagov/usagov-2021/assets/108532577/166b6593-10e7-4ffb-a316-2fbd47864bd8)
- All you have to do is navigate to the view, no selection needed. 
- Go back to the nodes you previously selected
- Verify that the EFCC is now selected. 
- (If you want to verify another way this view allows you to see all the nodes and if they are excluded. You can check that the path has a value of "Yes" ) 

Here is the current list of features: 
* /es/articulos/aprenda-sobre-las-fuerzas-armadas-de-ee-uu
* /es/articulos/ayuda-del-gobierno-para-personas-mayores
* /es/articulos/beneficios-del-gobierno-para-usted-y-su-familia
* /es/articulos/cinco-cosas-para-tramitar-el-pasaporte-de-un-menor
* /es/articulos/como-cambiar-de-profesion
* /es/articulos/cuatro-consejos-para-reportar-una-estafa
* /es/articulos/mejorando-la-salud-de-los-hombres
* /es/articulos/pasaportes-para-toda-la-familia
* /es/articulos/salud-mental-donde-encontrar-ayuda
* /features/get-help-for-homelessness-hunger-and-more
* /features/government-benefits-during-any-life-event
* /features/how-to-change-careers21
* /features/improving-mens-health
* /features/navigating-health-benefits-as-a-senior
* /features/passports-for-the-whole-family
* /features/programs-and-services-for-veterans
* /features/the-988-lifeline-and-other-mental-health-services

## Security Review
<!-- Checkboxes to indicate need for review -->

- [ ] Adds/updates software (including a library or Drupal module)
- [ ] Communication with external service
- [ ] Changes permissions or workflow
- [ ] Requires SSPP updates


## Reviewer Reminders
- Reviewed code changes
- Reviewed functionality
- Security review complete or not required

## Post PR Approval Instructions
Follow these steps as soon as you merge the new changes.

1. Go to the [USAGov Circle CI project](https://app.circleci.com/pipelines/github/usagov/usagov-2021).
2. Find the commit of this pull request.
3. Build and deploy the changes.
4. Update the Jira ticket by changing the ticket status to `Review in Test` and add a comment. State whether the change is already visible on [cms-dev.usa.gov](http://cms-dev.usa.gov/) and [beta-dev.usa.gov](http://beta-dev.usa.gov/), or if the deployment is still in process.
