### PR TITLE
USAGOV-1694: Add script to populate env vars from the annotated git tags

### DIFF
--- a/bin/deploy/get-latest-prod-containers
+++ b/bin/deploy/get-latest-prod-containers
@@ -8,7 +8,7 @@ export CMS_DIGEST=$(bin/deploy/git-annotation-parser.sh prod | grep deploy-cms |
 export WAF_DIGEST=$(bin/deploy/git-annotation-parser.sh prod | grep deploy-waf | awk '{print $3; }')
 export WWW_DIGEST=$(bin/deploy/git-annotation-parser.sh prod | grep deploy-www | awk '{print $3; }')
 
-echo CCI_BUILD_ID: $CCI_BUILD_ID
-echo CMS_DIGEST:   $CMS_DIGEST
-echo WAF_DIGEST:   $WAF_DIGEST
-echo WWW_DIGEST:   $WWW_DIGEST
+echo "CCI_BUILD_ID: $CCI_BUILD_ID"
+echo "CMS_DIGEST:   $CMS_DIGEST"
+echo "WAF_DIGEST:   $WAF_DIGEST"
+echo "WWW_DIGEST:   $WWW_DIGEST"

--- a/bin/deploy/get-latest-prod-containers.sh
+++ b/bin/deploy/get-latest-prod-containers.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+#
+# This is meant to be sourced (e.g.  . bin/deploy/get-latest-prod-containers.sh) to populate the 4 env vars below
+#
+export CCI_BUILD_ID=$(bin/deploy/git-annotation-parser.sh prod | grep deploy-cms | awk '{print $2; }')
+export CMS_DIGEST=$(bin/deploy/git-annotation-parser.sh prod | grep deploy-cms | awk '{print $3; }')
+export WAF_DIGEST=$(bin/deploy/git-annotation-parser.sh prod | grep deploy-waf | awk '{print $3; }')
+export WWW_DIGEST=$(bin/deploy/git-annotation-parser.sh prod | grep deploy-www | awk '{print $3; }')
+
+echo CCI_BUILD_ID: $CCI_BUILD_ID
+echo CMS_DIGEST:   $CMS_DIGEST
+echo WAF_DIGEST:   $WAF_DIGEST
+echo WWW_DIGEST:   $WWW_DIGEST


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
## Jira Task
<!--- Provide a link to the Jira ticket -->
https://cm-jira.usa.gov/browse/USAGOV-1694

## Description
<!--- Summarize the changes made in this pull request, not what it's for. -->

Create a script that populates environment variables from the latest production deployment annotated tags.  This is to be used for facilitating scripted restoration of our app containers.

## Type of Changes
<!--- Put an `x` in all the boxes that apply. -->
- [ ] New Feature
- [ ] Bugfix
- [ ] Frontend (Twig, Sass, JS)
  - Add screenshot showing what it should look like
- [ ] Drupal Config (requires "drush cim")
- [ ] New Modules (requires rebuild)
- [x] Infrastructure
  - [ ] CMS
  - [ ] WAF
  - [ ] Egress
  - [ ] Tools
- [ ] Other

## Testing Instructions
<!-- This instructions are different from “testing instructions” in Jira – those are typically for Content/UX stakeholders -->
<!-- Not “see Jira” – if they are really the same, copy and paste. -->

### Requires New Config
- [ ] Yes
- [ ] No

### Requires New Content
- [ ] Yes
- [ ] No

### Validation Steps
- Test instruction 1
- Test instruction 2
- Test instruction 3

## Security Review
<!-- Checkboxes to indicate need for review -->

- [ ] Adds/updates software (including a library or Drupal module)
- [ ] Communication with external service
- [ ] Changes permissions or workflow
- [ ] Requires SSPP updates


## Reviewer Reminders
- Reviewed code changes
- Reviewed functionality
- Security review complete or not required

## Post PR Approval Instructions
Follow these steps as soon as you merge the new changes.

1. Go to the [USAGov Circle CI project](https://app.circleci.com/pipelines/github/usagov/usagov-2021).
2. Find the commit of this pull request.
3. Build and deploy the changes.
4. Update the Jira ticket by changing the ticket status to `Review in Test` and add a comment. State whether the change is already visible on [cms-dev.usa.gov](http://cms-dev.usa.gov/) and [beta-dev.usa.gov](http://beta-dev.usa.gov/), or if the deployment is still in process.
