### PR TITLE
USAGOV-1652-nr-agent-update: updating nr agent to 10.22.0.12

### DIFF
--- a/bin/src/newrelic.sh
+++ b/bin/src/newrelic.sh
@@ -1,14 +1,22 @@
 #!/bin/sh
 
 # TODO: why the [ $(uname -m) != 'aarch64' ] clause? Was this meant to exclude local install?
-if [ $(uname -m) != 'aarch64' ]; then
-  export NR_VERSION='newrelic-php5-10.19.0.9-linux-musl'
-  export NR_LATEST_VERSION=$(curl -sS https://download.newrelic.com/php_agent/release/ | sed -n 's/.*>\(.*linux\-musl\).tar.gz<.*/\1/p') \
-    && cd /tmp \
-    && curl -L "https://download.newrelic.com/php_agent/archive/10.19.0.9/${NR_VERSION}.tar.gz" | tar -C /tmp -zx \
-    && NR_INSTALL_USE_CP_NOT_LN=1 NR_INSTALL_USE_CP_NOT_LN=1 /tmp/newrelic-php5-*/newrelic-install install \
-    && rm -rf /tmp/newrelic-php5-* /tmp/nrinstall* \
-    && sed -i \
+if [ "$(uname -m)" != 'aarch64' ]; then
+  export NR_VERSION_NUMBER='10.22.0.12'
+
+  NR_VERSION="newrelic-php5-$NR_VERSION_NUMBER-linux-musl"
+  export NR_VERSION
+
+  cd /tmp || exit
+
+  curl -L "https://download.newrelic.com/php_agent/archive/${NR_VERSION_NUMBER}/${NR_VERSION}.tar.gz" | tar -C /tmp -zx
+
+  export NR_INSTALL_USE_CP_NOT_LN=1
+  /tmp/newrelic-php5-*/newrelic-install install
+
+  rm -rf /tmp/newrelic-php5-* /tmp/nrinstall*
+
+  sed -i \
       -e "s/;\?newrelic.appname =.*/newrelic.appname = \"USA.gov\"/" \
       -e "s/;\?newrelic.process_host.display_name =.*/newrelic.process_host.display_name = usa-cms-local/" \
       -e 's/;\?newrelic.daemon.app_connect_timeout =.*/newrelic.daemon.app_connect_timeout=15s/' \
@@ -23,8 +31,10 @@ if [ $(uname -m) != 'aarch64' ]; then
       -e 's/;\?newrelic.error_collector.record_database_errors =.*/newrelic.error_collector.record_database_errors = true/' \
       /etc/php81/conf.d/newrelic.ini
 
-    if [ $NR_VERSION != $NR_LATEST_VERSION ]; then
-      # TODO: we never see this warning because it is emitted during image build.
-      echo "WARNING: New Relic latest version is '${NR_LATEST_VERSION}'; we are installing '${NR_VERSION}'"
+  NR_LATEST_VERSION="$(curl -sS https://download.newrelic.com/php_agent/release/ | sed -n 's/.*>\(.*linux\-musl\).tar.gz<.*/\1/p')"
+  export NR_LATEST_VERSION
+  if [ "$NR_VERSION" != "$NR_LATEST_VERSION" ]; then
+    # TODO: we never see this warning because it is emitted during image build.
+    echo "WARNING: New Relic latest version is '${NR_LATEST_VERSION}'; we are installing '${NR_VERSION}'"
   fi
 fi


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
## Jira Task

<!--- Provide a link to the Jira ticket -->
https://cm-jira.usa.gov/browse/USAGOV-1652

## Description
<!--- Summarize the changes made in this pull request, not what it's for. -->

## Type of Changes
<!--- Put an `x` in all the boxes that apply. -->
- [ ] New Feature
- [ ] Bugfix
- [ ] Frontend (Twig, Sass, JS)
  - Add screenshot showing what it should look like
- [ ] Drupal Config (requires "drush cim")
- [ ] New Modules (requires rebuild)
- [ ] Documentation
- [ ] Infrastructure
  - [ ] CMS
  - [ ] WAF
  - [ ] Egress
  - [ ] Tools
- [X] Other - software update

## Testing Instructions
Go to the changed environment in APM & Services on New Relic, click Environment, and check that the version number is corret.

### Change Requirements
<!-- Checkboxes to indicate need for changes to some part of the system -->

- [ ] Requires New Documentation (Link: {})
- [ ] Requires New Config
- [ ] Requires New Content

### Validation Steps

- Test instruction 1
- Test instruction 2
- Test instruction 3

## Security Review
<!-- Checkboxes to indicate need for review -->

- [ ] Adds/updates software (including a library or Drupal module)
- [ ] Communication with external service
- [ ] Changes permissions or workflow
- [ ] Requires SSPP updates


## Reviewer Reminders

- Reviewed code changes
- Reviewed functionality
- Security review complete or not required

## Post PR Approval Instructions

Follow these steps as soon as you merge the new changes.

1. Go to the [USAGov Circle CI project](https://app.circleci.com/pipelines/github/usagov/usagov-2021).
2. Find the commit of this pull request.
3. Build and deploy the changes.
4. Update the Jira ticket by changing the ticket status to `Review in Test` and add a comment. State whether the change is already visible on [cms-dev.usa.gov](http://cms-dev.usa.gov/) and [beta-dev.usa.gov](http://beta-dev.usa.gov/), or if the deployment is still in process.
