### PR TITLE
USAGOV-1772-show-search-state:

### DIFF
--- a/docs/BenefitsSearch.md
+++ b/docs/BenefitsSearch.md
@@ -119,7 +119,7 @@ If page is not tagged, the datalayer shows:
 "hasBenefitCategory": false,
 ```
 
-### JavaScript sources
+### JavaScript Sources
 
 Two JavaScript source files are required for the page to function properly.
 
@@ -164,7 +164,7 @@ bin/drush php:script scripts/drush/benefits-category-make-pages.php
 
 5. Associate terms to life events. You need to edit at least one term in English and one Spanish term from the benefits category vocabulary to reference one of the pages via the "Life Events" field.
 
-6. Enable the benefits search call-outs at `/admin/config/development/usagov_benefit_category_search`. Tick the box to display the call-outs and press the save button.
+6. Enable the benefits search call-outs at `/admin/config/development/usagov_benefit_category_search`. Press the button to enable the call-outs. This will also hide the life events carousel on the homepage.
 
 ## Known Issues and Concerns
 

--- a/web/modules/custom/usagov_benefit_category_search/usagov_benefit_category_search.links.menu.yml
+++ b/web/modules/custom/usagov_benefit_category_search/usagov_benefit_category_search.links.menu.yml
@@ -9,5 +9,5 @@ usagov_benefit_category_search.settings:
   title: 'Benefit Categories Search configuration'
   parent: usagov_benefit_category_search.admin
   route_name: usagov_benefit_category_search.settings
-  description: 'Configure Benefit Finder.'
+  description: 'Use this form to enable or disable showing the Benefits Search blocks'
   weight: 150


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
## Jira Task

<!--- Provide a link to the Jira ticket -->
https://cm-jira.usa.gov/browse/USAGOV-1772

## Description
<!--- Summarize the changes made in this pull request, not what it's for. -->
 Switch form to use state instead of cofig setting for showing and hiding the blocks on homepage and benefits nav page.

## Type of Changes
<!--- Put an `x` in all the boxes that apply. -->
- [x] New Feature
- [] Bugfix
- [ ] Frontend (Twig, Sass, JS)
  - Add screenshot showing what it should look like
- [ ] Drupal Config (requires "drush cim")
- [ ] New Modules (requires rebuild)
- [ ] Documentation
- [ ] Infrastructure
  - [ ] CMS
  - [ ] WAF
  - [ ] Egress
  - [ ] Tools
- [ ] Other

## Testing Instructions
<!-- This instructions are different from “testing instructions” in Jira – those are typically for Content/UX stakeholders -->
<!-- Not “see Jira” – if they are really the same, copy and paste. -->

Check that you have the benefits search working and set up to show the call-outs. Running the make-pages script should update the pages with the required content for you to test.

### Change Requirements
<!-- Checkboxes to indicate need for changes to some part of the system -->

- [ ] Requires New Documentation (Link: {})
- [ ] Requires New Config
- [ ] Requires New Content

### Validation Steps

- Go to `/admin/config/development/usagov_benefit_category_search` and enable the call-outs
- Go to English & Spanish homepage, confirm call-out displays
- Go to English & Spanish government benefits pages and confirm you see the call-out.
- Go to `/admin/config/development/usagov_benefit_category_search` and disable the call-outs
- Go to English & Spanish homepage, confirm you see the carousel of life events and no call-out.
- Go to English & Spanish government benefits pages and confirm you don't see the call out.

## Security Review
<!-- Checkboxes to indicate need for review -->

- [ ] Adds/updates software (including a library or Drupal module)
- [ ] Communication with external service
- [ ] Changes permissions or workflow
- [ ] Requires SSPP updates


## Reviewer Reminders

- Reviewed code changes
- Reviewed functionality
- Security review complete or not required

## Post PR Approval Instructions

Follow these steps as soon as you merge the new changes.

1. Go to the [USAGov Circle CI project](https://app.circleci.com/pipelines/github/usagov/usagov-2021).
2. Find the commit of this pull request.
3. Build and deploy the changes.
4. Update the Jira ticket by changing the ticket status to `Review in Test` and add a comment. State whether the change is already visible on [cms-dev.usa.gov](http://cms-dev.usa.gov/) and [beta-dev.usa.gov](http://beta-dev.usa.gov/), or if the deployment is still in process.
