### PR TITLE
USAGOV-1786-wizard-data_analytics-attribute: Add data_analytics attribute to wizard and fix next/previous button logic.

### DIFF
--- a/web/themes/custom/usagov/templates/wizard_2024/taxonomy-term--wizard.html.twig
+++ b/web/themes/custom/usagov/templates/wizard_2024/taxonomy-term--wizard.html.twig
@@ -4,6 +4,7 @@
   parent_tid
   child
   start_over
+  has_child
 #}
 
 {% if term.langcode.value == 'en' %}
@@ -19,6 +20,10 @@
 {% set attributes = attributes.addClass('usa-prose') %}
 {% set attributes = attributes.addClass('usagov-wizard--content') %}
 
+{% if has_child == false %}
+  {% set attributes = attributes.setAttribute('data-analytics', 'wizard-results-main-content') %}
+{% endif %}
+
 <div{{ attributes }}>
   <h1 id="skip-to-h1" class="text-red-50">{{ content.field_heading[0]['#context']['value'] }}</h1>
   {% if content.field_intro[0] %}
@@ -31,16 +36,14 @@
     {% endif %}
 
     {{ content.field_footer }}
-
     {# we want the start over button to be on the same line as the previous button
     if there's no next button, so put some logic here in the class property. #}
     <div class="margin-bottom-2 desktop:usa-reverse usagov-wizard-buttons
      {% if has_child %}grid-row{% else %}display-inline-block{% endif %}"
-      {% if has_child == 'FALSE' %}
+      {% if has_child == false %}
       {% if not (content.field_options_list[0]['contents']['#view_id']) %}
-      style="margin-top: 40px;" {% endif %}{% endif %}>
+        style="margin-top: 40px;" {% endif %}{% endif %}>
 
-      {% if (content.field_options_list[0]['contents']['#view_id']) %}
       {# Generate the url for the parent of this term to put in the 'previous' button. #}
       {% set previous_path = path('entity.taxonomy_term.canonical', {'taxonomy_term': parent_tid}) %}
       <button id="prior" class="usa-button usa-button--secondary usa-button--big margin-right-2" onclick="window.location.href = '{{ previous_path }}'">
@@ -52,7 +55,6 @@
                 onclick="if(document.querySelector(`input[name='options']:checked`)) { window.location.href = document.querySelector(`input[name='options']:checked`).value; }">
           {{ next_string }}</button>
       {% endif %}
-      {% endif %}
 
     </div>
   {% endif %}
@@ -60,17 +62,20 @@
     {# This link should be styled differently depending on if it's inline with
     the previous button, but only in mobile. So we need to get creative. #}
     {% if has_child %}
-      <div class="display-inline-block margin-top-2">
-        <a href="{{ path('entity.taxonomy_term.canonical', {'taxonomy_term': start_over_target_tid}) }}">{{ start_over_string }}</a>
-      </div>
+    <div class="display-inline-block margin-top-2">
+      <a href="{{ path('entity.taxonomy_term.canonical', {'taxonomy_term': start_over_target_tid}) }}"
+         data-analytics="wizard-start-over">{{ start_over_string }}</a>
+    </div>
     {% else %}
       {# have the element printed twice here, then use breakpoints to hide
       one of these elements. #}
       <div id="start-over-mobile" class="display-inline-block usa-button--unstyled text-center">
-        <a href="{{ path('entity.taxonomy_term.canonical', {'taxonomy_term': start_over_target_tid}) }}">{{ start_over_string }}</a>
+        <a href="{{ path('entity.taxonomy_term.canonical', {'taxonomy_term': start_over_target_tid}) }}"
+           data-analytics="wizard-start-over">{{ start_over_string }}</a>
       </div>
       <div id="start-over-desktop" class="margin-top-2">
-        <a href="{{ path('entity.taxonomy_term.canonical', {'taxonomy_term': start_over_target_tid}) }}">{{ start_over_string }}</a>
+        <a href="{{ path('entity.taxonomy_term.canonical', {'taxonomy_term': start_over_target_tid}) }}"
+           data-analytics="wizard-start-over">{{ start_over_string }}</a>
       </div>
     {% endif %}
   {% endif %}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
## Jira Task

<!--- Provide a link to the Jira ticket -->
https://cm-jira.usa.gov/browse/USAGOV-1786

## Description
<!--- Summarize the changes made in this pull request, not what it's for. -->
Update usagov_wizard.module to send a has_children variable to twig. Update wizard twig to add properties and fix logic.

## Type of Changes
<!--- Put an `x` in all the boxes that apply. -->
- [ X ] New Feature
- [ X ] Bugfix
- [ ] Frontend (Twig, Sass, JS)
![image](https://github.com/user-attachments/assets/cc50d800-f40d-42ad-886f-4417432fc53f)
![image](https://github.com/user-attachments/assets/1c9aef81-0d7b-42ce-90b2-7fd695f90c6c)
- [ ] Drupal Config (requires "drush cim")
- [ ] New Modules (requires rebuild)
- [ ] Documentation
- [ ] Infrastructure
  - [ ] CMS
  - [ ] WAF
  - [ ] Egress
  - [ ] Tools
- [ ] Other

## Testing Instructions
<!-- This instructions are different from “testing instructions” in Jira – those are typically for Content/UX stakeholders -->
<!-- Not “see Jira” – if they are really the same, copy and paste. -->
Please note, do not test this page with the second page of the wizard, with the question "Where did the scam take place?", as this page is built via html in the WYSWYG and needs updating once this PR is merged in.

1. Visit any page (other than the one noted above) in the wizard. 
2. The "start over" link has a `data-analytics` attribute. Note that since one link is being hidden by CSS at all times, there will be two start-over links in the DOM, since the user can only see one of them, I don't think this is an issue.
3. The start-over button behaves as expected.
4. The next/previous buttons look and behave as expected.
5. Visit the last page of any part of the wizard tree.
6. Open dev tools and search for "data-analytics".
7. The container for the main content section and both of the start over link has a `data-analytics` attribute, and the start-over link and Previous button appears and behaves as expected.

### Change Requirements
<!-- Checkboxes to indicate need for changes to some part of the system -->

- [ ] Requires New Documentation (Link: {})
- [ ] Requires New Config
- [ ] Requires New Content

## Security Review
<!-- Checkboxes to indicate need for review -->

- [ ] Adds/updates software (including a library or Drupal module)
- [ ] Communication with external service
- [ ] Changes permissions or workflow
- [ ] Requires SSPP updates


## Reviewer Reminders

- Reviewed code changes
- Reviewed functionality
- Security review complete or not required

## Post PR Approval Instructions

Follow these steps as soon as you merge the new changes.

1. Go to the [USAGov Circle CI project](https://app.circleci.com/pipelines/github/usagov/usagov-2021).
8. Find the commit of this pull request.
9. Build and deploy the changes.
10. Update the Jira ticket by changing the ticket status to `Review in Test` and add a comment. State whether the change is already visible on [cms-dev.usa.gov](http://cms-dev.usa.gov/) and [beta-dev.usa.gov](http://beta-dev.usa.gov/), or if the deployment is still in process.
