### PR TITLE
USAGOV-1904 Add open.usa.gov redirects to prod (hot patch)

### DIFF
--- a/.docker/src-waf/etc/nginx/conf.d/default.conf
+++ b/.docker/src-waf/etc/nginx/conf.d/default.conf
@@ -149,3 +149,18 @@ server {
        return 301 https://www.usa.gov;
     }
 }
+
+server {
+    # open.usa.gov redirects
+    server_name 127.0.0.1;
+    listen 8887;
+
+    location / {
+       # Note that the forwarded_host WILL match if we got to this port in the expected way.
+       if ($http_x_usa_forwarded_host ~* ^open\.usa\.gov$) {
+          include /etc/nginx/snippets/domain-rewrites-open.conf;
+	  return 301 https://www.gsa.gov/governmentwide-initiatives/us-open-government;
+       }
+       return 301 https://www.usa.gov;
+    }
+}

--- a/.docker/src-waf/etc/nginx/snippets/domain-redirects.conf
+++ b/.docker/src-waf/etc/nginx/snippets/domain-redirects.conf
@@ -140,3 +140,9 @@
     set $port 8886;
     break;
   }
+
+  ## open.usa.gov
+  if ($cf_forwarded_host ~* ^open\.usa\.gov$) {
+    set $port 8887;
+    break;
+  }

--- a/.docker/src-waf/etc/nginx/snippets/domain-rewrites-open.conf
+++ b/.docker/src-waf/etc/nginx/snippets/domain-rewrites-open.conf
@@ -1,0 +1,6 @@
+    # Rewrites for requests for Host: open.usa.gov
+
+    rewrite ^/national-action-plan/5/schedule-of-open-govt-public-meetings$ https://www.gsa.gov/governmentwide-initiatives/us-open-government/public-engagement permanent;
+    rewrite ^/national-action-plan/5/commitments$ https://www.gsa.gov/governmentwide-initiatives/us-open-government/progress-overview-by-theme-level permanent;
+    rewrite ^/national-action-plan/5$ https://www.gsa.gov/governmentwide-initiatives/us-open-government/resources#tab--Past-National-Action-Plans permanent;
+    rewrite ^/national-action-plan/5/NAP5-Self-Assessment$ https://www.gsa.gov/governmentwide-initiatives/us-open-government/resources#tab--Past-National-Action-Plans permanent;


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the title above -->
## Jira Task

<!--- Provide a link to the Jira ticket -->
https://cm-jira.usa.gov/browse/USAGOV-1904

## Description
<!--- Summarize the changes made in this pull request, not what it's for. -->
Added redirects for requests from open.usa.gov. 

## Type of Changes
<!--- Put an `x` in all the boxes that apply. -->
- [ ] New Feature
- [ ] Bugfix
- [ ] Frontend (Twig, Sass, JS)
  - Add screenshot showing what it should look like
- [ ] Drupal Config (requires "drush cim")
- [ ] New Modules (requires rebuild)
- [ ] Documentation
- [ ] Infrastructure
  - [ ] CMS
  - [x] WAF
  - [ ] Egress
  - [ ] Tools
- [ ] Other

## Testing Instructions
<!-- This instructions are different from “testing instructions” in Jira – those are typically for Content/UX stakeholders -->
<!-- Not “see Jira” – if they are really the same, copy and paste. -->

### Change Requirements
<!-- Checkboxes to indicate need for changes to some part of the system -->

- [ ] Requires New Documentation (Link: {})
- [ ] Requires New Config
- [ ] Requires New Content

### Validation Steps
 
Applies the same changes as in #1879, but to prod.

## Security Review
<!-- Checkboxes to indicate need for review -->

- [ ] Adds/updates software (including a library or Drupal module)
- [ ] Communication with external service
- [ ] Changes permissions or workflow
- [ ] Requires SSPP updates


## Reviewer Reminders

- Reviewed code changes
- Reviewed functionality
- Security review complete or not required

## Post PR Approval Instructions

Follow these steps as soon as you merge the new changes.

1. Go to the [USAGov Circle CI project](https://app.circleci.com/pipelines/github/usagov/usagov-2021).
2. Find the commit of this pull request.
3. Build and deploy the changes.
4. Update the Jira ticket by changing the ticket status to `Review in Test` and add a comment. State whether the change is already visible on [cms-dev.usa.gov](http://cms-dev.usa.gov/) and [beta-dev.usa.gov](http://beta-dev.usa.gov/), or if the deployment is still in process.
