### PR TITLE
USAGOV-1908: Un-comment some lines we need to prevent an error

### DIFF
--- a/web/modules/custom/usa_translation/usa_translation.module
+++ b/web/modules/custom/usa_translation/usa_translation.module
@@ -117,9 +117,9 @@ function usa_translation_page_attachments_alter(&$page) {
         && $entity->hasLinkTemplate('canonical')) {
         foreach ($entity->getTranslationLanguages() as $language) {
           // Skip any translation that cannot be viewed.
-          // $translation = $entity->getTranslation($language->getId());
-          // $access = $translation->access('view', NULL, TRUE);
-          // $cache->addCacheableDependency($access);
+          $translation = $entity->getTranslation($language->getId());
+          $access = $translation->access('view', NULL, TRUE);
+          $cache->addCacheableDependency($access);
           if (!$access->isAllowed()) {
             continue;
           }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
## Jira Task

<!--- Provide a link to the Jira ticket -->
https://cm-jira.usa.gov/browse/USAGOV-1908

## Description
<!--- Summarize the changes made in this pull request, not what it's for. -->

Uncomment three lines that it turns out we need (at least two of them, anyway). 

## Type of Changes
<!--- Put an `x` in all the boxes that apply. -->
- [ ] New Feature
- [x] Bugfix
- [ ] Frontend (Twig, Sass, JS)
  - Add screenshot showing what it should look like
- [ ] Drupal Config (requires "drush cim")
- [ ] New Modules (requires rebuild)
- [ ] Documentation
- [ ] Infrastructure
  - [ ] CMS
  - [ ] WAF
  - [ ] Egress
  - [ ] Tools
- [ ] Other

## Testing Instructions
<!-- This instructions are different from “testing instructions” in Jira – those are typically for Content/UX stakeholders -->
<!-- Not “see Jira” – if they are really the same, copy and paste. -->

### Change Requirements
<!-- Checkboxes to indicate need for changes to some part of the system -->

- [ ] Requires New Documentation (Link: {})
- [ ] Requires New Config
- [ ] Requires New Content

### Validation Steps

This change suppresses an error that occurred when the language toggle for a page pointed to a page that doesn't exist. (Of course we want that toggle to go away, but a site error is not the way to get there.) So you need to create that situation. 

I recommend viewing the behavior on the "dev" branch before switching to this branch: 

1. Log in.
2. Pick some page that has a Language toggle defined, and choose "Delete" 
3. You'll see a warning about a reference that will be orphaned. Open the page it links to in another window/tab. 
4. Proceed to delete the first page without addressing the reference. 
5. Reload the second page. You'll get a "The website encountered an unexpected error" message and you'll probably find something like this in your log: 

`Warning: Undefined variable $access in usa_translation_page_attachments_alter() (line 123 of /var/www/web/modules/custom/usa_translation/usa_translation.module)`

Now switch to the `USAGOV-1908-error-from-orphaned-toggle` branch and reload the page of step 5 again; it should load without error. 

## Security Review
<!-- Checkboxes to indicate need for review -->

- [ ] Adds/updates software (including a library or Drupal module)
- [ ] Communication with external service
- [ ] Changes permissions or workflow
- [ ] Requires SSPP updates


## Reviewer Reminders

- Reviewed code changes
- Reviewed functionality
- Security review complete or not required

## Post PR Approval Instructions

Follow these steps as soon as you merge the new changes.

1. Go to the [USAGov Circle CI project](https://app.circleci.com/pipelines/github/usagov/usagov-2021).
2. Find the commit of this pull request.
3. Build and deploy the changes.
4. Update the Jira ticket by changing the ticket status to `Review in Test` and add a comment. State whether the change is already visible on [cms-dev.usa.gov](http://cms-dev.usa.gov/) and [beta-dev.usa.gov](http://beta-dev.usa.gov/), or if the deployment is still in process.
