### PR TITLE
USAGOV-1982-event-log-revision: Add revision number to cf event log entries, to aid in NR queries

### DIFF
--- a/bin/cloudgov/events/get-events
+++ b/bin/cloudgov/events/get-events
@@ -105,7 +105,7 @@ declare -rA AUDIT_FIELDS=(
 
 ### Reformat event outoput into key:value pairs that can be more easily ingested by NewRelic (1)
 match='"\(.*\)","\(.*\)","\(.*\)","\(.*\)","\(.*\)","\(.*\)","\(.*\)"'
-replace='{"cfevent.metadata.guid":"\1","timestamp":"\2","cfevent.entity.type":"\3","cfevent.entity.actee_name":"\4","cfevent.entity.space_name":"\5","cfevent.entity.actor_type":"\6","cfevent.entity.actor_name":"\7"}'
+replace='{"cfevent.metadata.guid":"\1","timestamp":"\2","cfevent.entity.type":"\3","cfevent.entity.actee_name":"\4","cfevent.entity.space_name":"\5","cfevent.entity.actor_type":"\6","cfevent.entity.actor_name":"\7","mobomo.logrev.cfevent":"2"}'
 
 # For each category of audit events, perform a (possibly multi-page) query 
 for resource_type in ${!AUDIT_TYPES[@]}; do


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
## Jira Task

<!--- Provide a link to the Jira ticket -->
https://cm-jira.usa.gov/browse/USAGOV-1982

## Description
<!--- Summarize the changes made in this pull request, not what it's for. -->

## Type of Changes
<!--- Put an `x` in all the boxes that apply. -->
- [x] New Feature
- [ ] Bugfix
- [ ] Frontend (Twig, Sass, JS)
  - Add screenshot showing what it should look like
- [ ] Drupal Config (requires "drush cim")
- [ ] New Modules (requires rebuild)
- [ ] Documentation
- [x] Infrastructure
  - [ ] CMS
  - [ ] WAF
  - [ ] WWW
  - [ ] Egress
  - [ ] Tools
  - [x] Cron
- [ ] Other

## Testing Instructions

- I set up a specific value for mobomo.logrev.cfevent = "0.1.1"
- Then, I deployed the code to DR that would add that logrev to cfevents
- (that generated a couple appstop/appstart events at the time of deployment)
- I verified I could see those in NR, using the logrev as the query
- Then, I deleted the logs.lastrun from s3 (which makes get-events go back a month or so) *See Below*
- I added a date range of the 5 minutes around the deployment time, to verify all I saw was the expected appstart/appstop messages.
- Then, I removed the date range from the query and added "last 7 days" - after which I got a bunch more cf events in the results.

So, based on that it looks like NR is accepting my timestamp as the event time

```
# Delete logs.lastrun causing the cfevents cron job to get all available past events
SPACE=dr                                          
. bin/cloudgov/get-s3-access cron-event-storage $SPACE
aws s3 rm s3://$S3_BUCKET/cfevents/$SPACE/logs.lastrun
```

### Change Requirements
<!-- Checkboxes to indicate need for changes to some part of the system -->

- [ ] Requires New Documentation (Link: {})
- [ ] Requires New Config
- [ ] Requires New Content

### Validation Steps

- Test instruction 1
- Test instruction 2
- Test instruction 3

## Security Review
<!-- Checkboxes to indicate need for review -->

- [ ] Adds/updates software (including a library or Drupal module)
- [ ] Communication with external service
- [ ] Changes permissions or workflow
- [ ] Requires SSPP updates


## Reviewer Reminders

- Reviewed code changes
- Reviewed functionality
- Security review complete or not required

## Post PR Approval Instructions

Follow these steps as soon as you merge the new changes.

1. Go to the [USAGov Circle CI project](https://app.circleci.com/pipelines/github/usagov/usagov-2021).
2. Find the commit of this pull request.
3. Build and deploy the changes.
4. Update the Jira ticket by changing the ticket status to `Review in Test` and add a comment. State whether the change is already visible on [cms-dev.usa.gov](http://cms-dev.usa.gov/) and [beta-dev.usa.gov](http://beta-dev.usa.gov/), or if the deployment is still in process.
