### PR TITLE
USAGOV-1613: USAGOV-1613 - CEO form has extra space on the left

### DIFF
--- a/web/themes/custom/usagov/templates/field--node--field-custom-twig-content-elected-officials.html.twig
+++ b/web/themes/custom/usagov/templates/field--node--field-custom-twig-content-elected-officials.html.twig
@@ -40,7 +40,7 @@
           <strong>All fields are required.</strong>
         </p>
         <div id="error-border">
-          <div class="usa-form-spacing">
+          <div>
             <label id="myStreetAddress" class="usa-label" for="input-street">
               Street address
             </label>
@@ -57,7 +57,7 @@
               oninput="this.setCustomValidity('')"
               />
           </div>
-          <div class="usa-form-spacing">
+          <div>
             <label id="myCity" class="usa-label" for="input-city">City</label>
             <span id="city" class="errors"></span>
             <input
@@ -71,7 +71,7 @@
               oninvalid="this.setCustomValidity('Fill out the city field.')"
               oninput="this.setCustomValidity('')" />
           </div>
-          <div class="usa-form-spacing">
+          <div>
             <label id="input-state-label" class="usa-label" for="input-state">
               State
             </label>
@@ -146,7 +146,7 @@
               <span id="state" class="errors"></span>
             </div>
           </div>
-          <div class="usa-form-spacing">
+          <div>
             <label id="myZIP" class="usa-label" for="input-zip">ZIP code</label>
             <span id="zip" class="errors"></span>
             <input


### PR DESCRIPTION
<!--- Provide a link to the Jira ticket -->
https://cm-jira.usa.gov/browse/USAGOV-1613

## Description
remove the "spacing"-classes from the texboxes that were adding the extra space on them.

## Type of Changes
<!--- Put an `x` in all the boxes that apply. -->
- [ ] New Feature
- [ ] Bugfix
- [x] Frontend (Twig, Sass, JS)
- [ ] Drupal Config (requires "drush cim")
- [ ] New Modules (requires rebuild)
- [ ] Documentation
- [ ] Infrastructure
  - [ ] CMS
  - [ ] WAF
  - [ ] WWW
  - [ ] Egress
  - [ ] Tools
  - [ ] Cron
- [ ] Other

## Testing Instructions
You can simply open a page to `/elected-officials` and confirm whether the left-edge of the textboxes are aligned vertically with the _"All fields are required"_ text, and the _"Results are provided"_ text.

## Reviewer Reminders

- Reviewed code changes
- Reviewed functionality
- Security review complete or not required

## Post PR Approval Instructions

Follow these steps as soon as you merge the new changes.

1. Go to the [USAGov Circle CI project](https://app.circleci.com/pipelines/github/usagov/usagov-2021).
2. Find the commit of this pull request.
3. Build and deploy the changes.
4. Update the Jira ticket by changing the ticket status to `Review in Test` and add a comment. State whether the change is already visible on [cms-dev.usa.gov](http://cms-dev.usa.gov/) and [beta-dev.usa.gov](http://beta-dev.usa.gov/), or if the deployment is still in process.
