### PR TITLE
USAGOV-1164 - removing some extra echos from bootstrap.sh

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -221,16 +221,11 @@ if [ "${CF_INSTANCE_INDEX:-''}" == "0" ] && [ -z "${SKIP_DRUPAL_BOOTSTRAP:-}" ];
     fi
 
     drush cr
-    echo "Running: drush updatedb"
     drush updatedb --no-cache-clear -y
-    echo "Running: drush cim (potentially twice)"
     drush cim -y || drush cim -y
-    echo "Running: drush cim (once, again)"
     drush cim -y
-    echo "Notice: If a TXNDATA error is seen above this line, it means one of the drush-cim commands failed, which is ok as long as the config ultimately imported."
-    echo "However: If a TXNDATA error is seen after this line, we may need to revisit USAGOV-1164."
+    echo "Notice: If a TXNDATA error is seen above this line, we believe it is likley NewRelic having a connection-reset-by-peer issue. We dont believe this is causing drush-cim to crash."
 
-    echo "Running: node_access_rebuild()"
     drush php-eval "node_access_rebuild();" -y
 
     if [ x$initial_mm_state = x0 ]; then


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
We previously merged in a PR to have extra `echo` statements put into bootstrap.sh in order to collect more verbose information on the next deploy. Now that our research is done, we can remove some of the extra ones. I am keep one warning message in there.

<!--- Provide a link to the Jira ticket -->
https://cm-jira.usa.gov/browse/USAGOV-1164

## Description
Removed the extra `echo` lines from `boostrap.sh` now that we have collected our verbose logging. 

## Type of Changes
<!--- Put an `x` in all the boxes that apply. -->
- [ ] New Feature
- [ ] Bugfix
- [ ] Frontend (Twig, Sass, JS)
  - Add screenshot showing what it should look like
- [ ] Drupal Config (requires "drush cim")
- [ ] New Modules (requires rebuild)
- [ ] Documentation
- [ ] Infrastructure
  - [ ] CMS
  - [ ] WAF
  - [ ] WWW
  - [ ] Egress
  - [ ] Tools
  - [ ] Cron
- [x] Other

## Reviewer Reminders

- Reviewed code changes
- Reviewed functionality
- Security review complete or not required

## Post PR Approval Instructions

Follow these steps as soon as you merge the new changes.

1. Go to the [USAGov Circle CI project](https://app.circleci.com/pipelines/github/usagov/usagov-2021).
2. Find the commit of this pull request.
3. Build and deploy the changes.
4. Update the Jira ticket by changing the ticket status to `Review in Test` and add a comment. State whether the change is already visible on [cms-dev.usa.gov](http://cms-dev.usa.gov/) and [beta-dev.usa.gov](http://beta-dev.usa.gov/), or if the deployment is still in process.
