### PR TITLE
USAGOV-2066-hotfix-prod: Apply USAGOV-2066 es/ redirect fix to prod

### DIFF
--- a/web/modules/custom/usagov_ssg_postprocessing/src/EventSubscriber/TomeEventSubscriber.php
+++ b/web/modules/custom/usagov_ssg_postprocessing/src/EventSubscriber/TomeEventSubscriber.php
@@ -189,6 +189,15 @@ class TomeEventSubscriber implements EventSubscriberInterface {
   public function excludeInvalidPaths(PathPlaceholderEvent $event) {
     $path = $event->getPath();
 
+    if ($path === '/es/') {
+      // Tome should never request the spanish homepage with a trailing-slash.
+      // If it does request it, that is due to the path being linked in content.
+      // When tome runs, Drupal will redirect the request to `/es`, causing Tome
+      // to rewrite the contents of `es/index.html` with a refresh redirect.
+      $event->setInvalid();
+      return;
+    }
+
     if (preg_match('/(es\/)?node\/\d+$/', $path)) {
       $event->setInvalid();
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
## Jira Task

<!--- Provide a link to the Jira ticket -->
https://cm-jira.usa.gov/browse/USAGOV-2066

Hotfix for prod; prevents tome from overwriting its /es output with a redirect (due to links in content with a trailing slash). 