### PR TITLE
USAGOV-2016: Redirect with a special character in URL

### DIFF
--- a/web/modules/custom/usagov_redirect/src/EventSubscriber/Custom404Subscriber.php
+++ b/web/modules/custom/usagov_redirect/src/EventSubscriber/Custom404Subscriber.php
@@ -3,9 +3,10 @@
 namespace Drupal\usagov_redirect\EventSubscriber;
 
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-use Symfony\Component\HttpKernel\Event\ExceptionEvent;
-use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Event\ExceptionEvent;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\HttpKernel\KernelEvents;
 
 /**
  * Class Custom404Subscriber
@@ -23,7 +24,7 @@ class Custom404Subscriber implements EventSubscriberInterface {
     $exception = $event->getThrowable();
 
     // We only want to react on 404 (Not Found) pages.
-    if (!($exception instanceof \Symfony\Component\HttpKernel\Exception\NotFoundHttpException)) {
+    if (!($exception instanceof NotFoundHttpException)) {
       return;
     }
 
@@ -31,10 +32,10 @@ class Custom404Subscriber implements EventSubscriberInterface {
     $currentPath = ltrim($_SERVER['REQUEST_URI'], '/');
     $testPath = $currentPath;
     $badCharacters = [
-      '%C2%A0',     /* non-breaking space */
-      '%E2%80%89',  /* think space */
-      '%20',        /* regular space (encoded) */
-      ' '           /* regular space */
+      '%C2%A0', /* non-breaking space */
+      '%E2%80%89', /* think space */
+      '%20', /* regular space (encoded) */
+      ' ' /* regular space */
     ];
     foreach ($badCharacters as $badCharacter) {
       $testPath = str_replace($badCharacter, '', $testPath);
@@ -46,14 +47,14 @@ class Custom404Subscriber implements EventSubscriberInterface {
     }
 
     // Test is $testPath really points to an existing Drupal node. Bail if it does not.
-    $testSysPath = \Drupal::service('path_alias.manager')->getPathByAlias('/'.$testPath);
+    $testSysPath = \Drupal::service('path_alias.manager')->getPathByAlias('/' . $testPath);
     if (!str_starts_with($testSysPath, '/node/')) {
       return;
     }
 
     // At this point we know that if we were to go to this same path with the problem-characters removed,
     // then we should get a valid page-load rather than a 404. So now we will redirect there.
-    header("Location: /" . $testPath, true, 301);
+    header("Location: /" . $testPath, TRUE, 301);
     exit();
   }
 
@@ -65,4 +66,5 @@ class Custom404Subscriber implements EventSubscriberInterface {
       KernelEvents::EXCEPTION => 'onException',
     ];
   }
+
 }

--- a/web/modules/custom/usagov_redirect/src/EventSubscriber/Custom404Subscriber.php
+++ b/web/modules/custom/usagov_redirect/src/EventSubscriber/Custom404Subscriber.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Drupal\usagov_redirect\EventSubscriber;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\ExceptionEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Class Custom404Subscriber
+ * Listens to 404 errors and performs custom actions.
+ */
+class Custom404Subscriber implements EventSubscriberInterface {
+
+  /**
+   * Responds to 404 Not Found exceptions.
+   *
+   * @param \Symfony\Component\HttpKernel\Event\ExceptionEvent $event
+   *   The event to process.
+   */
+  public function onException(ExceptionEvent $event) {
+    $exception = $event->getThrowable();
+
+    // We only want to react on 404 (Not Found) pages.
+    if (!($exception instanceof \Symfony\Component\HttpKernel\Exception\NotFoundHttpException)) {
+      return;
+    }
+
+    // Determine what path we would be on if we remove all known problem-characters from this path
+    $currentPath = ltrim($_SERVER['REQUEST_URI'], '/');
+    $testPath = $currentPath;
+    $badCharacters = [
+      '%C2%A0',     /* non-breaking space */
+      '%E2%80%89',  /* think space */
+      '%20',        /* regular space (encoded) */
+      ' '           /* regular space */
+    ];
+    foreach ($badCharacters as $badCharacter) {
+      $testPath = str_replace($badCharacter, '', $testPath);
+    }
+
+    // We only want to react when the URL-path contains certain known problem-characters.
+    if ($testPath == $currentPath) {
+      return;
+    }
+
+    // Test is $testPath really points to an existing Drupal node. Bail if it does not.
+    $testSysPath = \Drupal::service('path_alias.manager')->getPathByAlias('/'.$testPath);
+    if (!str_starts_with($testSysPath, '/node/')) {
+      return;
+    }
+
+    // At this point we know that if we were to go to this same path with the problem-characters removed,
+    // then we should get a valid page-load rather than a 404. So now we will redirect there.
+    header("Location: /" . $testPath, true, 301);
+    exit();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents() {
+    return [
+      KernelEvents::EXCEPTION => 'onException',
+    ];
+  }
+}

--- a/web/modules/custom/usagov_redirect/usagov_redirect.services.yml
+++ b/web/modules/custom/usagov_redirect/usagov_redirect.services.yml
@@ -7,3 +7,7 @@ services:
     class: Drupal\usagov_redirect\PathProcessor\UsagovInboundPathProcessor
     tags:
       - { name: path_processor_inbound }
+  usagov_redirect.404_subscriber:
+    class: Drupal\usagov_redirect\EventSubscriber\Custom404Subscriber
+    tags:
+      - { name: event_subscriber }


### PR DESCRIPTION
Redirect when there's a non-breaking space at the end of a request path

<!--- Provide a link to the Jira ticket -->
https://cm-jira.usa.gov/browse/USAGOV-2016

## Description
When Drupal is about to return a 404-Not-Found page, a hook will jump in, check if there is a [non-breaking-space/regular-space/skinny-space] in the URL. In the event where removing the special character would send the user to a valid page-path, the user will now get perm-redirected to that path.

## Type of Changes
<!--- Put an `x` in all the boxes that apply. -->
- [ ] New Feature
- [ ] Bugfix
- [ ] Frontend (Twig, Sass, JS)
  - Add screenshot showing what it should look like
- [ ] Drupal Config (requires "drush cim")
- [ ] New Modules (requires rebuild)
- [ ] Documentation
- [ ] Infrastructure
  - [ ] CMS
  - [ ] WAF
  - [ ] WWW
  - [ ] Egress
  - [ ] Tools
  - [ ] Cron
- [x] Other

## Testing Instructions
* Before merging, try going to a path like `/voter-fraud%C2%A0` - notice how you land on a `404 Not Found` page.
* Now merge the branch
* Flush Drupal cache
* Try going to the page of `/voter-fraud%C2%A0` again - notice how you get redirected to `/voter-fraud`
* This test can be repeated to any valid URL with a `%20` or `%C2%A0` injected anywhere into the URL

## Reviewer Reminders

- Reviewed code changes
- Reviewed functionality
- Security review complete or not required

## Post PR Approval Instructions

Follow these steps as soon as you merge the new changes.

1. Go to the [USAGov Circle CI project](https://app.circleci.com/pipelines/github/usagov/usagov-2021).
2. Find the commit of this pull request.
3. Build and deploy the changes.
4. Update the Jira ticket by changing the ticket status to `Review in Test` and add a comment. State whether the change is already visible on [cms-dev.usa.gov](http://cms-dev.usa.gov/) and [beta-dev.usa.gov](http://beta-dev.usa.gov/), or if the deployment is still in process.
