### PR TITLE
USAGOV-2016-revert: Reverting previous PR before the deploy tonight

### DIFF
--- a/.docker/src-cms/etc/nginx/partials/drupal.conf.tmpl
+++ b/.docker/src-cms/etc/nginx/partials/drupal.conf.tmpl
@@ -79,19 +79,6 @@
     }
 
     location / {
-        # Decode the URI for proper matching
-        set $decoded_uri $uri;
-        # We will react on URLs ending with spaces, non-breaking spaces, thin-space, and Em-space
-        if ($decoded_uri ~* ^(.+?)(%C2%A0|\xA0|%E2%80%89|\xE2\x80\x89|%E2%80%83|\xE2\x80\x83)+$) {
-            set $clean_uri $1;
-            return 301 $clean_uri;
-        }
-        # Match and strip other partial %C2 sequences from the end of the URI
-        if ($uri ~* ^(.+?)(%C2|\xC2)+$) {
-            set $clean_uri $1;
-            return 301 $clean_uri;
-        }
-
         # try_files $uri @rewrite; # For Drupal <= 6
         try_files $uri /index.php?$query_string; # For Drupal >= 7
     }

--- a/.docker/src-www/etc/nginx/partials/staticsite.conf.tmpl
+++ b/.docker/src-www/etc/nginx/partials/staticsite.conf.tmpl
@@ -1,18 +1,4 @@
 
-    location / {
-        # Decode the URI for proper matching
-        set $decoded_uri $uri;
-        if ($decoded_uri ~* ^(.+?)(%C2%A0|\xA0|%E2%80%89|\xE2\x80\x89|%E2%80%83|\xE2\x80\x83)+$) {
-            set $clean_uri $1;
-            return 301 $clean_uri;
-        }
-        # Match and strip other partial %C2 sequences from the end of the URI
-        if ($uri ~* ^(.+?)(%C2|\xC2)+$) {
-            set $clean_uri $1;
-            return 301 $clean_uri;
-        }
-    }
-
     # spanish main url - easier as a separate case vs in another regex
     location ~* ^/(es)$ {
       error_page 404 @notFoundSpanish;


### PR DESCRIPTION
Reverting previous PR before the deploy tonight

<!--- Provide a link to the Jira ticket -->
https://cm-jira.usa.gov/browse/USAGOV-2016

## Description
The previous PR has logic which does not seem to trigger. While it probably is not hurting anything, we can revert it before the deploy tonight.

## Type of Changes
<!--- Put an `x` in all the boxes that apply. -->
- [ ] New Feature
- [ ] Bugfix
- [ ] Frontend (Twig, Sass, JS)
  - Add screenshot showing what it should look like
- [ ] Drupal Config (requires "drush cim")
- [ ] New Modules (requires rebuild)
- [ ] Documentation
- [ ] Infrastructure
  - [ ] CMS
  - [ ] WAF
  - [ ] WWW
  - [ ] Egress
  - [ ] Tools
  - [ ] Cron
- [x] Other


## Post PR Approval Instructions

Follow these steps as soon as you merge the new changes.

1. Go to the [USAGov Circle CI project](https://app.circleci.com/pipelines/github/usagov/usagov-2021).
2. Find the commit of this pull request.
3. Build and deploy the changes.
4. Update the Jira ticket by changing the ticket status to `Review in Test` and add a comment. State whether the change is already visible on [cms-dev.usa.gov](http://cms-dev.usa.gov/) and [beta-dev.usa.gov](http://beta-dev.usa.gov/), or if the deployment is still in process.
