### PR TITLE
USAGOV-2060: nginx config cleanup for gsa.benefits.gov

### DIFF
--- a/.docker/src-waf/etc/nginx/conf.d/default.conf
+++ b/.docker/src-waf/etc/nginx/conf.d/default.conf
@@ -215,10 +215,6 @@ server {
        if ($http_x_usa_forwarded_host ~* ^(www\.)?govloans\.gov$)  {
           set $HostMatchFail "matched";
        }
-       # gsa.benefits.gov is for testing; we can remove it after cutover
-       if ($http_x_usa_forwarded_host ~* ^gsa\.benefits\.gov$) {
-          set $HostMatchFail "matched";
-       }
 
        if ($HostMatchFail = "NOMATCH") {
           # didn't match expected host; redirect to home page.

--- a/.docker/src-waf/etc/nginx/snippets/domain-redirects.conf
+++ b/.docker/src-waf/etc/nginx/snippets/domain-redirects.conf
@@ -153,12 +153,6 @@
     break;
   }
 
-  ## gsa.benefits.gov is for testing of the benefits rewrites and can be removed after cutover:
-  if ($cf_forwarded_host ~* ^gsa\.benefits\.gov$) {
-    set $port 8889;
-    break;
-  }
-
   ## govloans.gov (part of the benefits.gov transition)
   if ($cf_forwarded_host ~* ^(www\.)?govloans\.gov$) {
     set $port 8889;


### PR DESCRIPTION
nginx config cleanup: remove configuration for gsa.benefits.gov

<!--- Provide a link to the Jira ticket -->
https://cm-jira.usa.gov/browse/USAGOV-2060

## Description
Deleted some redirects

## Type of Changes
<!--- Put an `x` in all the boxes that apply. -->
- [ ] New Feature
- [ ] Bugfix
- [ ] Frontend (Twig, Sass, JS)
- [ ] Drupal Config (requires "drush cim")
- [ ] New Modules (requires rebuild)
- [ ] Documentation
- [ ] Infrastructure
  - [ ] CMS
  - [x] WAF
  - [ ] WWW
  - [ ] Egress
  - [ ] Tools
  - [ ] Cron
- [ ] Other

## Testing Instructions
There may be no test here to do since the domains doesn't exist anymore? 

## Reviewer Reminders

- Reviewed code changes
- Reviewed functionality
- Security review complete or not required

## Post PR Approval Instructions

Follow these steps as soon as you merge the new changes.

1. Go to the [USAGov Circle CI project](https://app.circleci.com/pipelines/github/usagov/usagov-2021).
2. Find the commit of this pull request.
3. Build and deploy the changes.
4. Update the Jira ticket by changing the ticket status to `Review in Test` and add a comment. State whether the change is already visible on [cms-dev.usa.gov](http://cms-dev.usa.gov/) and [beta-dev.usa.gov](http://beta-dev.usa.gov/), or if the deployment is still in process.
