### PR TITLE
USAGOV-2103 Add fed agency letter pages to the Pub Pages Report

### DIFF
--- a/web/modules/custom/usagov_ssg_postprocessing/src/Drush/Commands/PublishedPagesCommands.php
+++ b/web/modules/custom/usagov_ssg_postprocessing/src/Drush/Commands/PublishedPagesCommands.php
@@ -132,8 +132,26 @@ final class PublishedPagesCommands extends DrushCommands {
       ->execute();
 
     foreach ($nids as $nid) {
+
+      // Get DataLayer information on this node
       $node = $this->entityTypeManager->getStorage('node')->load($nid);
       $row = $this->getNodeRow($node)->toArray();
+
+      // Save this row into the spreadsheet
+      $this->saveNodeRow($out, $node, $row);
+
+      // If this is a Directory-Index, add in all letter pages (USAGOV-2103)
+      if ($row[3] == 'federal_directory_index') {
+        $baseUrl = $row[4];
+        for ($lett = ord('a'); $lett <= ord('z'); $lett++) {
+          $row[4] = $baseUrl . '/' . chr($lett);
+          $this->saveNodeRow($out, $node, $row);
+        }
+      }
+    }
+  }
+
+  protected function saveNodeRow($out, $node, $row): void {
 
       $row = array_map(fn($col) => trim($col), $row);
       $this->alter_and_fputcsv($out, $row);
@@ -151,7 +169,6 @@ final class PublishedPagesCommands extends DrushCommands {
           }
         }
       }
-    }
   }
 
   protected function saveWizardRows($out): void {


### PR DESCRIPTION
<!--- Provide a link to the Jira ticket -->
https://cm-jira.usa.gov/browse/USAGOV-2103

## Description
Repeating write-line commands for the Agency-Letter pages to include all letters in the report.

## Type of Changes
<!--- Put an `x` in all the boxes that apply. -->
- [ ] New Feature
- [ ] Bugfix
- [ ] Frontend (Twig, Sass, JS)
- [ ] Drupal Config (requires "drush cim")
- [ ] New Modules (requires rebuild)
- [ ] Documentation
- [ ] Infrastructure
  - [ ] CMS
  - [ ] WAF
  - [ ] WWW
  - [ ] Egress
  - [ ] Tools
  - [ ] Cron
- [x] Other

## Testing Instructions
Run the `bin/static-site` script. Check the Pub Pages report at `web/modules/custom/usagov_ssg_postprocessing/files/published-pages.csv` and confirm the agency-letter pages show with `/a` and `/b`, and `/c`, etc, after them.

## Reviewer Reminders

- Reviewed code changes
- Reviewed functionality
- Security review complete or not required

## Post PR Approval Instructions

Follow these steps as soon as you merge the new changes.

1. Go to the [USAGov Circle CI project](https://app.circleci.com/pipelines/github/usagov/usagov-2021).
2. Find the commit of this pull request.
3. Build and deploy the changes.
4. Update the Jira ticket by changing the ticket status to `Review in Test` and add a comment. State whether the change is already visible on [cms-dev.usa.gov](http://cms-dev.usa.gov/) and [beta-dev.usa.gov](http://beta-dev.usa.gov/), or if the deployment is still in process.
