### PR TITLE
USAGOV-2153: Moderated content view has some incorrect entries

### DIFF
--- a/config/sync/views.view.moderated_content.yml
+++ b/config/sync/views.view.moderated_content.yml
@@ -725,6 +725,52 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
+        nid:
+          id: nid
+          table: node_field_data
+          field: nid
+          relationship: nid
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: nid
+          plugin_id: numeric
+          operator: 'not empty'
+          value:
+            min: ''
+            max: ''
+            value: ''
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            min_placeholder: ''
+            max_placeholder: ''
+            placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
       filter_groups:
         operator: AND
         groups:


### PR DESCRIPTION
<!--- Provide a link to the Jira ticket -->
https://cm-jira.usa.gov/browse/USAGOV-2153

## Description
Added another filter onto the View to only include revision-results that link to their associated node.

## Type of Changes
<!--- Put an `x` in all the boxes that apply. -->
- [ ] New Feature
- [ ] Bugfix
- [ ] Frontend (Twig, Sass, JS)
- [x] Drupal Config (requires "drush cim")
- [ ] New Modules (requires rebuild)
- [ ] Documentation
- [ ] Infrastructure
- [ ] Other

## Testing Instructions
* First, on the Dev branch, do a `git pull` and then a `bin/drush cim` 
* observe the URL https://localhost/admin/structure/views/view/moderated_content/edit/moderated_content and notice how "Votar en persona el día de las elecciones en EE. U" shows up (as the last result for me)
* Now switch to this branch, do another `git pull` and `bin/drush cim`
* Notice how that mentioned result goes away now when refreshing the page

## Reviewer Reminders

- Reviewed code changes
- Reviewed functionality
- Security review complete or not required

## Post PR Approval Instructions

Follow these steps as soon as you merge the new changes.

1. Go to the [USAGov Circle CI project](https://app.circleci.com/pipelines/github/usagov/usagov-2021).
2. Find the commit of this pull request.
3. Build and deploy the changes.
4. Update the Jira ticket by changing the ticket status to `Review in Test` and add a comment. State whether the change is already visible on [cms-dev.usa.gov](http://cms-dev.usa.gov/) and [beta-dev.usa.gov](http://beta-dev.usa.gov/), or if the deployment is still in process.
