### PR TITLE
Usagov 2016 v4

### DIFF
--- a/.docker/src-www/etc/nginx/partials/404s.conf.tmpl
+++ b/.docker/src-www/etc/nginx/partials/404s.conf.tmpl
@@ -3,6 +3,19 @@
 
     location @notFoundEnglish {
       allow all;
+
+      # Decode the URI for proper matching
+      set $decoded_uri $uri;
+      if ($decoded_uri ~* ^(.+?)(%C2%A0|\xA0|%E2%80%89|\xE2\x80\x89|%E2%80%83|\xE2\x80\x83)+$) {
+          set $clean_uri $1;
+          return 301 $clean_uri;
+      }
+      # Match and strip other partial %C2 sequences from the end of the URI
+      if ($uri ~* ^(.+?)(%C2|\xC2)+$) {
+          set $clean_uri $1;
+          return 301 $clean_uri;
+      }
+
       error_page 403 404 @notFoundEnglishFallback;
       proxy_intercept_errors on;
       recursive_error_pages on;

--- a/.docker/src-www/etc/nginx/partials/internal_redirects.conf
+++ b/.docker/src-www/etc/nginx/partials/internal_redirects.conf
@@ -1,19 +1,5 @@
     # Proxy directives for the public site. May be included in CMS for local/cms testing
 
-    location / {
-        # Decode the URI for proper matching
-        set $decoded_uri $uri;
-        if ($decoded_uri ~* ^(.+?)(%C2%A0|\xA0|%E2%80%89|\xE2\x80\x89|%E2%80%83|\xE2\x80\x83)+$) {
-            set $clean_uri $1;
-            return 301 $clean_uri;
-        }
-        # Match and strip other partial %C2 sequences from the end of the URI
-        if ($uri ~* ^(.+?)(%C2|\xC2)+$) {
-            set $clean_uri $1;
-            return 301 $clean_uri;
-        }
-    }
-
     # Federal and state directory PERMANENT redirects:
     rewrite ^/federal-agencies/a$ /agency-index permanent;
     rewrite ^/federal-agencies/([^/])$ /agency-index/$1 permanent;


### PR DESCRIPTION
<!--- Provide a link to the Jira ticket -->
https://cm-jira.usa.gov/browse/USAGOV-2016

## Description
Adding in nginx redirects rule

## Type of Changes
<!--- Put an `x` in all the boxes that apply. -->
- [ ] New Feature
- [ ] Bugfix
- [ ] Frontend (Twig, Sass, JS)
  - Add screenshot showing what it should look like
- [ ] Drupal Config (requires "drush cim")
- [ ] New Modules (requires rebuild)
- [ ] Documentation
- [ ] Infrastructure
  - [ ] CMS
  - [ ] WAF
  - [ ] WWW
  - [ ] Egress
  - [ ] Tools
  - [ ] Cron
- [ ] Other

## Testing Instructions
* Going to a URL of `/foo/bar` should load a not-found page, which is fine
* but after merging this, going to `/foo/bar%C2%A0` should redirect you to `/foo/bar`
* and so should `/foo/bar%E2%80%89` and `/foo/bar%E2%80%83`
* mainly I want to make sure that this configuration is now crashing the WWW nginx container on Dev since this is kind of a blind edit there as I dont quite know how to run the WWW container on my local

## Reviewer Reminders

- Reviewed code changes
- Reviewed functionality
- Security review complete or not required

## Post PR Approval Instructions

Follow these steps as soon as you merge the new changes.

1. Go to the [USAGov Circle CI project](https://app.circleci.com/pipelines/github/usagov/usagov-2021).
2. Find the commit of this pull request.
3. Build and deploy the changes.
4. Update the Jira ticket by changing the ticket status to `Review in Test` and add a comment. State whether the change is already visible on [cms-dev.usa.gov](http://cms-dev.usa.gov/) and [beta-dev.usa.gov](http://beta-dev.usa.gov/), or if the deployment is still in process.
