### PR TITLE
USAGOV-2181-fix-phpstan-admin-styles: fix phpstan errors for admin st…

### DIFF
--- a/web/modules/custom/usa_admin_styles/src/Controller/UsaAdminController.php
+++ b/web/modules/custom/usa_admin_styles/src/Controller/UsaAdminController.php
@@ -18,9 +18,12 @@ class UsaAdminController extends ControllerBase {
     private SystemManager $systemManager,
   ) {}
 
-  // Returns a page with some instructions and the same list of links as are in the menu.
-  public function mainPage() {
-
+  /**
+  * Returns a page with some instructions and the same list of links as are in the menu.
+  *
+  * @return array<mixed>
+  */
+  public function mainPage(): array {
     // Loosely based on Drupal\system\Controller\SystemController::overview.
     // That function assumes links will have blocks associated with them, which is not the case
     // when we have provided a URL-based link instead of a route.

--- a/web/modules/custom/usa_admin_styles/src/Controller/UsaAdminController.php
+++ b/web/modules/custom/usa_admin_styles/src/Controller/UsaAdminController.php
@@ -21,7 +21,7 @@ class UsaAdminController extends ControllerBase {
   /**
   * Returns a page with some instructions and the same list of links as are in the menu.
   *
-  * @return array<mixed>
+  * @return array<string, mixed>
   */
   public function mainPage(): array {
     // Loosely based on Drupal\system\Controller\SystemController::overview.

--- a/web/modules/custom/usa_admin_styles/usa_admin_styles.module
+++ b/web/modules/custom/usa_admin_styles/usa_admin_styles.module
@@ -2,14 +2,23 @@
 
 use Drupal\Core\Form\FormStateInterface;
 
-function usa_admin_styles_preprocess_page(&$variables) {
+/**
+ * Implements hook_preprocess_HOOK() for page templates.
+ *
+ * Attaches the mylib library to all admin pages.
+ *
+ * @param array<mixed> $variables
+ */
+function usa_admin_styles_preprocess_page(array &$variables): void {
   $variables['#attached']['library'][] = 'usa_admin_styles/mylib';
 }
 
 /**
  * Attaches a library to only the node forms. This covers the add and edit forms for nodes.
+ *
+ * @param array<mixed> $form
  */
-function usa_admin_styles_form_node_form_alter(&$form, FormStateInterface $form_state, $form_id) {
+function usa_admin_styles_form_node_form_alter(array &$form, FormStateInterface $form_state, string $form_id): void {
   // The accordionButtonSubmitFix library suppresses form submit events from accordion buttons in
   // rich text editor previews. This was not an issue with ckeditor 4 (which implemented previews
   // in an iframe), but is a problem in ckeditor 5 -- all preview content is within the node

--- a/web/modules/custom/usa_admin_styles/usa_admin_styles.module
+++ b/web/modules/custom/usa_admin_styles/usa_admin_styles.module
@@ -7,7 +7,7 @@ use Drupal\Core\Form\FormStateInterface;
  *
  * Attaches the mylib library to all admin pages.
  *
- * @param array<mixed> $variables
+ * @param array<string, mixed> $variables
  */
 function usa_admin_styles_preprocess_page(array &$variables): void {
   $variables['#attached']['library'][] = 'usa_admin_styles/mylib';
@@ -16,7 +16,7 @@ function usa_admin_styles_preprocess_page(array &$variables): void {
 /**
  * Attaches a library to only the node forms. This covers the add and edit forms for nodes.
  *
- * @param array<mixed> $form
+ * @param array<string, mixed> $form
  */
 function usa_admin_styles_form_node_form_alter(array &$form, FormStateInterface $form_state, string $form_id): void {
   // The accordionButtonSubmitFix library suppresses form submit events from accordion buttons in


### PR DESCRIPTION
…yles

<!--- Provide a general summary of your changes in the title above -->
## Jira Task

<!--- Provide a link to the Jira ticket -->
https://cm-jira.usa.gov/browse/USAGOV-2181

## Description
<!--- Summarize the changes made in this pull request, not what it's for. -->

## Type of Changes
<!--- Put an `x` in all the boxes that apply. -->
- [ ] New Feature
- [ ] Bugfix
- [ ] Frontend (Twig, Sass, JS)
  - Add screenshot showing what it should look like
- [ ] Drupal Config (requires "drush cim")
- [ ] New Modules (requires rebuild)
- [ ] Documentation
- [ ] Infrastructure
  - [ ] CMS
  - [ ] WAF
  - [ ] WWW
  - [ ] Egress
  - [ ] Tools
  - [ ] Cron
- [ ] Other

## Testing Instructions
<!-- This instructions are different from “testing instructions” in Jira – those are typically for Content/UX stakeholders -->
<!-- Not “see Jira” – if they are really the same, copy and paste. -->

### Change Requirements
<!-- Checkboxes to indicate need for changes to some part of the system -->

- [ ] Requires New Documentation (Link: {})
- [ ] Requires New Config
- [ ] Requires New Content

### Validation Steps

- Test instruction 1
- Test instruction 2
- Test instruction 3

## Security Review
<!-- Checkboxes to indicate need for review -->

- [ ] Adds/updates software (including a library or Drupal module)
- [ ] Communication with external service
- [ ] Changes permissions or workflow
- [ ] Requires SSPP updates


## Reviewer Reminders

- Reviewed code changes
- Reviewed functionality
- Security review complete or not required

## Post PR Approval Instructions

Follow these steps as soon as you merge the new changes.

1. Go to the [USAGov Circle CI project](https://app.circleci.com/pipelines/github/usagov/usagov-2021).
2. Find the commit of this pull request.
3. Build and deploy the changes.
4. Update the Jira ticket by changing the ticket status to `Review in Test` and add a comment. State whether the change is already visible on [cms-dev.usa.gov](http://cms-dev.usa.gov/) and [beta-dev.usa.gov](http://beta-dev.usa.gov/), or if the deployment is still in process.
