### PR TITLE
USAGOV-2183-fix-phpstan-content-moderation: fix phphstan errors conte…

### DIFF
--- a/web/modules/custom/usa_content_moderation_notifications/usa_content_moderation_notifications.module
+++ b/web/modules/custom/usa_content_moderation_notifications/usa_content_moderation_notifications.module
@@ -9,8 +9,10 @@ use Drupal\user\Entity\User;
 
 /**
  * Update the content notification logic.
+ *
+ * @param array<mixed> $message
  */
-function usa_content_moderation_notifications_mail_alter(&$message) {
+function usa_content_moderation_notifications_mail_alter(array &$message): void {
   $currentuser = User::load(\Drupal::currentUser()->id());
   $hasPermission = $currentuser->hasPermission('Self content notification');
   $message['to'] = \Drupal::config('system.site')->get('mail');

--- a/web/modules/custom/usa_content_moderation_notifications/usa_content_moderation_notifications.module
+++ b/web/modules/custom/usa_content_moderation_notifications/usa_content_moderation_notifications.module
@@ -10,7 +10,7 @@ use Drupal\user\Entity\User;
 /**
  * Update the content notification logic.
  *
- * @param array<mixed> $message
+ * @param array<string, mixed> $message
  */
 function usa_content_moderation_notifications_mail_alter(array &$message): void {
   $currentuser = User::load(\Drupal::currentUser()->id());


### PR DESCRIPTION
…nt moderation

<!--- Provide a general summary of your changes in the title above -->
## Jira Task

<!--- Provide a link to the Jira ticket -->
https://cm-jira.usa.gov/browse/USAGOV-2183

## Description
<!--- Summarize the changes made in this pull request, not what it's for. -->

## Type of Changes
<!--- Put an `x` in all the boxes that apply. -->
- [ ] New Feature
- [ ] Bugfix
- [ ] Frontend (Twig, Sass, JS)
  - Add screenshot showing what it should look like
- [ ] Drupal Config (requires "drush cim")
- [ ] New Modules (requires rebuild)
- [ ] Documentation
- [ ] Infrastructure
  - [ ] CMS
  - [ ] WAF
  - [ ] WWW
  - [ ] Egress
  - [ ] Tools
  - [ ] Cron
- [ ] Other

## Testing Instructions
<!-- This instructions are different from “testing instructions” in Jira – those are typically for Content/UX stakeholders -->
<!-- Not “see Jira” – if they are really the same, copy and paste. -->

### Change Requirements
<!-- Checkboxes to indicate need for changes to some part of the system -->

- [ ] Requires New Documentation (Link: {})
- [ ] Requires New Config
- [ ] Requires New Content

### Validation Steps

- Test instruction 1
- Test instruction 2
- Test instruction 3

## Security Review
<!-- Checkboxes to indicate need for review -->

- [ ] Adds/updates software (including a library or Drupal module)
- [ ] Communication with external service
- [ ] Changes permissions or workflow
- [ ] Requires SSPP updates


## Reviewer Reminders

- Reviewed code changes
- Reviewed functionality
- Security review complete or not required

## Post PR Approval Instructions

Follow these steps as soon as you merge the new changes.

1. Go to the [USAGov Circle CI project](https://app.circleci.com/pipelines/github/usagov/usagov-2021).
2. Find the commit of this pull request.
3. Build and deploy the changes.
4. Update the Jira ticket by changing the ticket status to `Review in Test` and add a comment. State whether the change is already visible on [cms-dev.usa.gov](http://cms-dev.usa.gov/) and [beta-dev.usa.gov](http://beta-dev.usa.gov/), or if the deployment is still in process.
