### PR TITLE
USAGOV-2188-fix-phpstan-workflow: fix phpstan errors for workflow module

### DIFF
--- a/web/modules/custom/usa_workflow/src/UsaWorkflowPermissionChecker.php
+++ b/web/modules/custom/usa_workflow/src/UsaWorkflowPermissionChecker.php
@@ -46,10 +46,10 @@ class UsaWorkflowPermissionChecker implements ContainerInjectionInterface {
   /**
    * WfUserPermission.
    *
-   * @return array
+   * @return array<string, mixed>
    *   the value should be of type array
    */
-  public function wfUserPermission() {
+  public function wfUserPermission(): array {
     $return = [];
 
     $node_param = $this->routeMatch->getParameter('node');

--- a/web/modules/custom/usa_workflow/usa_workflow.module
+++ b/web/modules/custom/usa_workflow/usa_workflow.module
@@ -9,8 +9,10 @@ use Drupal\Core\Form\FormStateInterface;
 
 /**
  * @inheritDoc
+ *
+ * @param array<string, mixed> $form
  */
-function usa_workflow_form_alter(&$form, FormStateInterface $form_state, $form_id) {
+function usa_workflow_form_alter(array &$form, FormStateInterface $form_state, string $form_id): void {
   $newForm = [
     'node_basic_page_form',
     'node_wizard_step_form',
@@ -38,8 +40,10 @@ function usa_workflow_form_alter(&$form, FormStateInterface $form_state, $form_i
 
 /**
  * @inheritDoc
+ *
+ * @param array<string, mixed> $data
  */
-function usa_workflow_menu_local_tasks_alter(&$data, $route_name) {
+function usa_workflow_menu_local_tasks_alter(array &$data, string $route_name): void {
   $routes = [
     'entity.node.canonical',
     'entity.node.edit_form',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
## Jira Task

<!--- Provide a link to the Jira ticket -->
https://cm-jira.usa.gov/browse/USAGOV-2188

## Description
<!--- Summarize the changes made in this pull request, not what it's for. -->

## Type of Changes
<!--- Put an `x` in all the boxes that apply. -->
- [ ] New Feature
- [X] Bugfix
- [ ] Frontend (Twig, Sass, JS)
  - Add screenshot showing what it should look like
- [ ] Drupal Config (requires "drush cim")
- [ ] New Modules (requires rebuild)
- [ ] Documentation
- [ ] Infrastructure
  - [ ] CMS
  - [ ] WAF
  - [ ] WWW
  - [ ] Egress
  - [ ] Tools
  - [ ] Cron
- [ ] Other

## Testing Instructions
<!-- This instructions are different from “testing instructions” in Jira – those are typically for Content/UX stakeholders -->
<!-- Not “see Jira” – if they are really the same, copy and paste. -->

### Change Requirements
<!-- Checkboxes to indicate need for changes to some part of the system -->

- [ ] Requires New Documentation (Link: {})
- [ ] Requires New Config
- [ ] Requires New Content

### Validation Steps

- Test instruction 1
- Test instruction 2
- Test instruction 3

## Security Review
<!-- Checkboxes to indicate need for review -->

- [ ] Adds/updates software (including a library or Drupal module)
- [ ] Communication with external service
- [ ] Changes permissions or workflow
- [ ] Requires SSPP updates


## Reviewer Reminders

- Reviewed code changes
- Reviewed functionality
- Security review complete or not required

## Post PR Approval Instructions

Follow these steps as soon as you merge the new changes.

1. Go to the [USAGov Circle CI project](https://app.circleci.com/pipelines/github/usagov/usagov-2021).
2. Find the commit of this pull request.
3. Build and deploy the changes.
4. Update the Jira ticket by changing the ticket status to `Review in Test` and add a comment. State whether the change is already visible on [cms-dev.usa.gov](http://cms-dev.usa.gov/) and [beta-dev.usa.gov](http://beta-dev.usa.gov/), or if the deployment is still in process.
