### PR TITLE
USAGOV-2189: Fix PHPStan findings in usagov_ckeditor5_source_editing_fixup

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ submitting a pull request.
 
 [back to top](#usagov-2021)
 
-## Checking PHP dode style and syntax errors
+## Checking PHP code style and syntax errors
 PHPCodesniffer and the parallel linting tools should be installed automatically on a local environment via `composer install`. PHPCodeSniffer is used to ensure new code follows Drupal's coding standard. The parallel linter will check for PHP syntax errors. If they detect any errors, they must be fixed before a PR of changes can be accepted.
 
 The following composer scripts are aliases for running these tools.
@@ -264,8 +264,12 @@ It's defined as a dev dependency in `composer.json` and will be installed automa
 
 The following composer scripts are aliases for running PHPStan
 
-* Check for errors at the level configured in `phpstan.neon`
-  `./bin/composer phpcs-errors`:
+* Check for errors at the level configured in `phpstan.neon`:
+
+  `./bin/composer phpstan`
+
+   (optionally, supply a file or directory name starting with `web/`)
+
 
 ## Project restart/reset
 Sometimes, Docker problems arise after an upgrade and a more complete restart is needed. After closing down and

--- a/web/modules/custom/usagov_ckeditor5_source_editing_fixup/usagov_ckeditor5_source_editing_fixup.module
+++ b/web/modules/custom/usagov_ckeditor5_source_editing_fixup/usagov_ckeditor5_source_editing_fixup.module
@@ -6,8 +6,10 @@
  * This enables us to add elements to the "Source Editing" elements of a
  * CKEditor5 editor configuration, even if a disabled plugin would also supply them.
  * See https://www.drupal.org/project/drupal/issues/3410100#comment-15457015
+ *
+ * @param array<string, mixed> $definitions
  */
-function usagov_ckeditor5_source_editing_fixup_config_schema_info_alter(&$definitions) {
+function usagov_ckeditor5_source_editing_fixup_config_schema_info_alter(array &$definitions): void {
   if (isset($definitions['ckeditor5.plugin.ckeditor5_sourceEditing'])) {
     unset($definitions['ckeditor5.plugin.ckeditor5_sourceEditing']['mapping']['allowed_tags']['sequence']['constraints']['SourceEditingRedundantTags']);
   }


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the title above -->
## Jira Task

<!--- Provide a link to the Jira ticket -->
https://cm-jira.usa.gov/browse/USAGOV-2189

## Description
<!--- Summarize the changes made in this pull request, not what it's for. -->
Added type hints. 
Also made a couple of corrections to README.md

## Type of Changes
<!--- Put an `x` in all the boxes that apply. -->
- [ ] New Feature
- [x] Bugfix
- [ ] Frontend (Twig, Sass, JS)
  - Add screenshot showing what it should look like
- [ ] Drupal Config (requires "drush cim")
- [ ] New Modules (requires rebuild)
- [ ] Documentation
- [ ] Infrastructure
  - [ ] CMS
  - [ ] WAF
  - [ ] WWW
  - [ ] Egress
  - [ ] Tools
  - [ ] Cron
- [ ] Other

## Testing Instructions
<!-- This instructions are different from “testing instructions” in Jira – those are typically for Content/UX stakeholders -->
<!-- Not “see Jira” – if they are really the same, copy and paste. -->

### Change Requirements
<!-- Checkboxes to indicate need for changes to some part of the system -->

- [ ] Requires New Documentation (Link: {})
- [ ] Requires New Config
- [ ] Requires New Content

### Validation Steps

Verify no errors from: 
```
bin/composer phpstan analyse web/modules/custom/usagov_ckeditor5_source_editing_fixup
```

In addition, I know why this module exists. If you open this form in the admin area, you should be able to remove tags from the "Source Editing" plugin field, then add them back, without error messages. We're suppressing a rule that prevented adding the `div` tag there. Comment in the code explains why (if you really want to know). 

http://localhost/admin/config/content/formats/manage/uswds


## Security Review
<!-- Checkboxes to indicate need for review -->

- [ ] Adds/updates software (including a library or Drupal module)
- [ ] Communication with external service
- [ ] Changes permissions or workflow
- [ ] Requires SSPP updates


## Reviewer Reminders

- Reviewed code changes
- Reviewed functionality
- Security review complete or not required

## Post PR Approval Instructions

Follow these steps as soon as you merge the new changes.

1. Go to the [USAGov Circle CI project](https://app.circleci.com/pipelines/github/usagov/usagov-2021).
2. Find the commit of this pull request.
3. Build and deploy the changes.
4. Update the Jira ticket by changing the ticket status to `Review in Test` and add a comment. State whether the change is already visible on [cms-dev.usa.gov](http://cms-dev.usa.gov/) and [beta-dev.usa.gov](http://beta-dev.usa.gov/), or if the deployment is still in process.
