### PR TITLE
USAGOV-2185: Fix PHPStan errors for usa_translation module

### DIFF
--- a/web/modules/custom/usa_translation/usa_translation.module
+++ b/web/modules/custom/usa_translation/usa_translation.module
@@ -30,6 +30,8 @@ function usa_translation_node_translation_delete(NodeInterface $node): void {
 
 /**
  * Implements hook_page_attachments_alter().
+ *
+ * @param array<string, mixed> $page
  */
 function usa_translation_page_attachments_alter(array &$page): void {
   $cache = CacheableMetadata::createFromRenderArray($page);

--- a/web/modules/custom/usa_translation/usa_translation.module
+++ b/web/modules/custom/usa_translation/usa_translation.module
@@ -1,6 +1,5 @@
 <?php
 
-
 /**
  * @file
  * Self explained.

--- a/web/modules/custom/usa_translation/usa_translation.module
+++ b/web/modules/custom/usa_translation/usa_translation.module
@@ -1,5 +1,6 @@
 <?php
 
+
 /**
  * @file
  * Self explained.
@@ -15,7 +16,7 @@ use Drupal\taxonomy\TermInterface;
 /**
  * Implements hook_ENTITY_TYPE_translation_delete().
  */
-function usa_translation_node_translation_delete(NodeInterface $node) {
+function usa_translation_node_translation_delete(NodeInterface $node): void {
   $node_lang = $node->language()->getId();
   $menu_link_manager = \Drupal::service('plugin.manager.menu.link');
   $result = $menu_link_manager->loadLinksByRoute('entity.node.canonical', ['node' => $node->id()]);
@@ -31,7 +32,7 @@ function usa_translation_node_translation_delete(NodeInterface $node) {
 /**
  * Implements hook_page_attachments_alter().
  */
-function usa_translation_page_attachments_alter(&$page) {
+function usa_translation_page_attachments_alter(array &$page): void {
   $cache = CacheableMetadata::createFromRenderArray($page);
   $route_match = \Drupal::routeMatch();
 


### PR DESCRIPTION
Fix PHPStan errors for usa_translation module

<!--- Provide a link to the Jira ticket -->
https://cm-jira.usa.gov/browse/USAGOV-2185

## Description
Added in the missing type-declarations into the functions signatures mentioned by the reporter. 

## Type of Changes
<!--- Put an `x` in all the boxes that apply. -->
- [ ] New Feature
- [ ] Bugfix
- [ ] Frontend (Twig, Sass, JS)
- [ ] Drupal Config (requires "drush cim")
- [ ] New Modules (requires rebuild)
- [ ] Documentation
- [ ] Infrastructure
- [x] Other

## Testing Instructions
The updated functions trigger when deleting a page-node that has an associated menu item. And viewing a page-node (after the cache has been cleared). As long as the pages don't crash here, we are good.

## Reviewer Reminders

- Reviewed code changes
- Reviewed functionality
- Security review complete or not required

## Post PR Approval Instructions

Follow these steps as soon as you merge the new changes.

1. Go to the [USAGov Circle CI project](https://app.circleci.com/pipelines/github/usagov/usagov-2021).
2. Find the commit of this pull request.
3. Build and deploy the changes.
4. Update the Jira ticket by changing the ticket status to `Review in Test` and add a comment. State whether the change is already visible on [cms-dev.usa.gov](http://cms-dev.usa.gov/) and [beta-dev.usa.gov](http://beta-dev.usa.gov/), or if the deployment is still in process.
