### PR TITLE
USAGOV-2094: Cache busting for updating these two icons

### DIFF
--- a/web/themes/custom/usagov/templates/footer-secondary.html.twig
+++ b/web/themes/custom/usagov/templates/footer-secondary.html.twig
@@ -21,7 +21,7 @@
 	{
 		'name':'Twitter',
 		'url':'https://twitter.com/',
-		'icon':'X_Twitter_Icon.svg',
+		'icon':'X_Twitter_Icon.svg?version=2',
 		'alt_text':'X Twitter USAGov',
 	},
 	{

--- a/web/themes/custom/usagov/templates/sharethispage.html.twig
+++ b/web/themes/custom/usagov/templates/sharethispage.html.twig
@@ -34,12 +34,12 @@
 			</a>
 			<a aria-labelledby="share-page twr" href="{{ twitter }}{{ url }}">
 				<div class="share-icon-div">
-					<img class="share-icon" id="twr" src="/themes/custom/usagov/images/social-media-icons/X_Twitter_Icon.svg " alt="X Twitter USAGov"/>
+					<img class="share-icon" id="twr" src="/themes/custom/usagov/images/social-media-icons/X_Twitter_Icon.svg?version=2" alt="X Twitter USAGov"/>
 				</div>
 			</a>
 			<a aria-labelledby="share-page em" href="{{ email }}{{ url }}">
 				<div class="share-icon-div">
-					<img class="share-icon" id="em" src="/themes/custom/usagov/images/social-media-icons/Email_Icon.svg" alt="Email"/>
+					<img class="share-icon" id="em" src="/themes/custom/usagov/images/social-media-icons/Email_Icon.svg?version=2" alt="Email"/>
 				</div>
 			</a>
 		</div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
## Jira Task

<!--- Provide a link to the Jira ticket -->
https://cm-jira.usa.gov/browse/USAGOV-2094

## Description
Adding cache-busting for these two seldomly-updated icons.
Let me know if I should make the query-string dynamic. Right now I am just making it `?version=2` as these icons are very rarely ever changed.  

## Type of Changes
<!--- Put an `x` in all the boxes that apply. -->
- [ ] New Feature
- [ ] Bugfix
- [x] Frontend (Twig, Sass, JS)
- [ ] Drupal Config (requires "drush cim")
- [ ] New Modules (requires rebuild)
- [ ] Documentation
- [ ] Infrastructure
- [ ] Other

## Testing Instructions
This may be for Julia to test as I was not able to reproduce the last issue mentioned in the ticket. I believe because Julia's phone stored the old icon in browser-cache. But this should fix this edge-case.

## Post PR Approval Instructions

Follow these steps as soon as you merge the new changes.

1. Go to the [USAGov Circle CI project](https://app.circleci.com/pipelines/github/usagov/usagov-2021).
2. Find the commit of this pull request.
3. Build and deploy the changes.
4. Update the Jira ticket by changing the ticket status to `Review in Test` and add a comment. State whether the change is already visible on [cms-dev.usa.gov](http://cms-dev.usa.gov/) and [beta-dev.usa.gov](http://beta-dev.usa.gov/), or if the deployment is still in process.
