### PR TITLE
USAGOV-2292:State pages have Go button with incorrect lang

### DIFF
--- a/web/themes/custom/usagov/scripts/stateDirectory.js
+++ b/web/themes/custom/usagov/scripts/stateDirectory.js
@@ -1,6 +1,6 @@
 jQuery(document).ready(function ($) {
   "use strict";
-  var docLang = [document.documentElement.lang];
+  var docLang = String(document.documentElement.lang);
 
   // hidden label for a11y
   const hiddenLabel = docLang === "es" ? "Elija o escriba el estado o territorio:" : "Select or type your state or territory:";


### PR DESCRIPTION
State pages have the "Go" button with incorrect language

<!--- Provide a link to the Jira ticket -->
https://cm-jira.usa.gov/browse/USAGOV-2292

## Description
Fixed a JavaScript bug that was causing a script to misunderstand what the page's language was.

## Type of Changes
<!--- Put an `x` in all the boxes that apply. -->
- [ ] New Feature
- [ ] Bugfix
- [x] Frontend (Twig, Sass, JS)
- [ ] Drupal Config (requires "drush cim")
- [ ] New Modules (requires rebuild)
- [ ] Documentation
- [ ] Infrastructure
- [ ] Other

## Testing Instructions
* Merge code in
* Clear Drupal cache
* Clear browser cache
* Go to https://www.usa.gov/es/gobiernos-estatales and expect the button to no longer say "Go"

## Reviewer Reminders

- Reviewed code changes
- Reviewed functionality
- Security review complete or not required

## Post PR Approval Instructions

Follow these steps as soon as you merge the new changes.

1. Go to the [USAGov Circle CI project](https://app.circleci.com/pipelines/github/usagov/usagov-2021).
2. Find the commit of this pull request.
3. Build and deploy the changes.
4. Update the Jira ticket by changing the ticket status to `Review in Test` and add a comment. State whether the change is already visible on [cms-dev.usa.gov](http://cms-dev.usa.gov/) and [beta-dev.usa.gov](http://beta-dev.usa.gov/), or if the deployment is still in process.
