### PR TITLE
USAGOV-2348: Remove branch filters for deployment to dev

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -821,31 +821,13 @@ workflows:
     jobs:
       - approve-build-and-push-container:
           type: approval
-          filters:
-            branches:
-              only:
-                - dr
-                - dev
-                - stage
-                - prod
       - build-and-push-container:
           requires:
             - approve-build-and-push-container
-          filters:
-            branches:
-              only:
-                - dr
-                - dev
-                - stage
-                - prod
       - approve-dev-deployment:
           type: approval
           requires:
             - build-and-push-container
-          filters:
-            branches:
-              only:
-              - dev
       - approve-dr-deployment:
           type: approval
           requires:
@@ -857,10 +839,6 @@ workflows:
       - deploy-to-cloudgov-dev:
           requires:
             - approve-dev-deployment
-          filters:
-            branches:
-              only:
-              - dev
       - deploy-to-cloudgov-dr:
           requires:
             - approve-dr-deployment


### PR DESCRIPTION
This is for discussion. If we agree it's a good idea, I'll create a Jira ticket and a properly-labeled PR. 

I am proposing that we remove the **branch** filters for dev deployment, so developers can deploy any branch to dev. 

**Reason:** I'm tired of adding my feature branch name to .circleci/config.yml and then taking it back out, and I'm tired of reminding others to remove feature branch names from .circleci/config.yml. Maybe you're tired of it too? 

I think the only possible disadvantage to this is that when you merge to dev, you might have to pay attention to the branch you're deploying in CircleCI, in case someone has just pushed a feature branch at the same time. I think we can handle that. 