### PR TITLE
USAGOV-2381: Reinstate the share-this-page section

### DIFF
--- a/web/themes/custom/usagov/templates/sharethispage.html.twig
+++ b/web/themes/custom/usagov/templates/sharethispage.html.twig
@@ -18,16 +18,35 @@
 {% set path = drupal_url('node/'~nodeID) %}
 
 {% if path|render not in exclusions %}
-	{% set facebook = 'https://www.facebook.com/sharer/sharer.php?u=' %}
-	{% set twitter = 'https://twitter.com/intent/tweet?source=webclient&text=' %}
-	{% set email = 'mailto:?subject=' %}
-	{% set baseURL = url('<front>') %}
-	{% set url = baseURL|render~path|render[1:] %}
+        {% set facebook = 'https://www.facebook.com/sharer/sharer.php?u=' %}
+        {% set twitter = 'https://twitter.com/intent/tweet?source=webclient&text=' %}
+        {% set email = 'mailto:?subject=' %}
+        {% set baseURL = url('<front>') %}
+        {% set url = baseURL|render~path|render[1:] %}
 
-	<!-- Social Media icons were removed in USAGOV-2374 -->
+        <div id="sm-share">
+                <span id="share-page">{{ lang == 'en' ? "SHARE THIS PAGE:" : "COMPARTA ESTA PÁGINA:" }}</span>
+                <div class="share-icons">
+                        <a aria-labelledby="share-page fb" href="{{ facebook }}{{ url }}&amp;v=3">
+                                <div class="share-icon-div">
+                                        <img class="share-icon" id="fb" src="/themes/custom/usagov/images/social-media-icons/Facebook_Icon.svg" alt="Facebook"/>
+                                </div>
+                        </a>
+                        <a aria-labelledby="share-page twr" href="{{ twitter }}{{ url }}">
+                                <div class="share-icon-div">
+                                        <img class="share-icon" id="twr" src="/themes/custom/usagov/images/social-media-icons/X_Twitter_Icon.svg?version=2" alt="X Twitter USAGov"/>
+                                </div>
+                        </a>
+                        <a aria-labelledby="share-page em" href="{{ email }}{{ url }}">
+                                <div class="share-icon-div">
+                                        <img class="share-icon" id="em" src="/themes/custom/usagov/images/social-media-icons/Email_Icon.svg?version=2" alt="Email"/>
+                                </div>
+                        </a>
+                </div>
+        </div>
 
-	{% if (term_name == "Standard Page") or (term_name == "Standard Page- Nav Hidden") or (term_name == "") or (content_type == "wizard") or (content_type == "wizard_step") %}
+        {% if (term_name == "Standard Page") or (term_name == "Standard Page- Nav Hidden") or (term_name == "") or (content_type == "wizard") or (content_type == "wizard_step") %}
 
-		<div class="border-top-05  border-base-lightest"></div>
-	{% endif %}
+                <div class="border-top-05  border-base-lightest"></div>
+        {% endif %}
 {% endif %}


### PR DESCRIPTION
Reinstate the "share this page" section that was removed in USAGOV-2374

<!--- Provide a link to the Jira ticket -->
https://cm-jira.usa.gov/browse/USAGOV-2381

## Description
Restored the template that was previously erased

## Type of Changes
<!--- Put an `x` in all the boxes that apply. -->
- [ ] New Feature
- [ ] Bugfix
- [x] Frontend (Twig, Sass, JS)
- [ ] Drupal Config (requires "drush cim")
- [ ] New Modules (requires rebuild)
- [ ] Documentation
- [ ] Infrastructure
- [ ] Other

## Testing Instructions
Ensure the Share feature is back on regular pages (seen at the bottom of the content area on content-pages).

## Reviewer Reminders

- Reviewed code changes
- Reviewed functionality
- Security review complete or not required

## Post PR Approval Instructions

Follow these steps as soon as you merge the new changes.

1. Go to the [USAGov Circle CI project](https://app.circleci.com/pipelines/github/usagov/usagov-2021).
2. Find the commit of this pull request.
3. Build and deploy the changes.
4. Update the Jira ticket by changing the ticket status to `Review in Test` and add a comment. State whether the change is already visible on [cms-dev.usa.gov](http://cms-dev.usa.gov/) and [beta-dev.usa.gov](http://beta-dev.usa.gov/), or if the deployment is still in process.
