### PR TITLE
USAGOV-2391: Update WAF to nginx 1.28

### DIFF
--- a/.docker/Dockerfile-waf
+++ b/.docker/Dockerfile-waf
@@ -1,4 +1,4 @@
-ARG NGINX_VERSION="1.27.4"
+ARG NGINX_VERSION="1.28.0"
 FROM nginx:${NGINX_VERSION}
 
 LABEL maintainer="USA.gov Web Ops"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
Update WAF to nginx 1.28

<!--- Provide a link to the Jira ticket -->
https://cm-jira.usa.gov/browse/USAGOV-2391

## Description
Updated the base-version used in ths Dockerfile, and rebuilt, and watched the compile logs.

## Type of Changes
<!--- Put an `x` in all the boxes that apply. -->
- [ ] New Feature
- [ ] Bugfix
- [ ] Frontend (Twig, Sass, JS)
  - Add screenshot showing what it should look like
- [ ] Drupal Config (requires "drush cim")
- [ ] New Modules (requires rebuild)
- [ ] Documentation
- [ ] Infrastructure
  - [ ] CMS
  - [x] WAF
  - [ ] WWW
  - [ ] Egress
  - [ ] Tools
  - [ ] Cron
- [ ] Other

## Testing Instructions
In order to compile the WAF locally to confirm this compiles:
* `cd .docker`
* `docker build --force-rm -t gsatts/usagov-2021:waf-daleTest123 -f ./Dockerfile-waf .`
* `docker run -d --name waf-container --rm gsatts/usagov-2021:waf-daleTest123`
* `docker exec -it waf-container bash`
* then, inside the box you can `nginx -v` and `nginx -V`, and you should see `nginx version: nginx/1.28.0`


## Reviewer Reminders

- Reviewed code changes
- Reviewed functionality
- Security review complete or not required

## Post PR Approval Instructions

Follow these steps as soon as you merge the new changes.

1. Go to the [USAGov Circle CI project](https://app.circleci.com/pipelines/github/usagov/usagov-2021).
2. Find the commit of this pull request.
3. Build and deploy the changes.
4. Update the Jira ticket by changing the ticket status to `Review in Test` and add a comment. State whether the change is already visible on [cms-dev.usa.gov](http://cms-dev.usa.gov/) and [beta-dev.usa.gov](http://beta-dev.usa.gov/), or if the deployment is still in process.
