### PR TITLE
USAGOV-2408: Silence a false-positive Snyk alert

### DIFF
--- a/.docker/.snyk
+++ b/.docker/.snyk
@@ -1,5 +1,11 @@
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
+version: v1.25.0
 ignore:
   SNYK-DEBIAN12-ZLIB-6008963:
     - '*':
         reason: "We have update Dockerfile-WAF to force-remove the old version of zlib after compiling the new one from source. But Snyk does not know this. See comments in USAGOV-2242 for more details."
+        expires: '2025-12-31T00:00:00.000Z'
+  SNYK-JS-MOCHA-2863123:
+    - "@ckeditor/ckeditor5-dev-utils" :
+        reason: "yarn.lock shows mocha 7.2.0 as a dependency, but the regex called out by this vulnerability does not appear anywhere in the javascript built and deployed with this module."
         expires: '2025-12-31T00:00:00.000Z'

--- a/bin/scan-container
+++ b/bin/scan-container
@@ -24,13 +24,10 @@ CTAG=${2:-$GITBRANCH}
 THRESHOLD=${3:-low}
 
 # Explicitly turn off DOCKER_CONTENT_TRUST, as snyk are not signing their images.
-# Mount nothing over the yarn.lock file in uswds_ckeditor_integration; we don't install those deps
-# and it throws false positives for us.
 docker run --disable-content-trust -it --rm \
     -e "SNYK_TOKEN=$SNYK_TOKEN" \
     -v /var/run/docker.sock:/var/run/docker.sock \
     -v $(pwd)/.docker:/app \
-    -v "/tmp/nosuchdir:/app/web/modules/contrib/uswds_ckeditor_integration/yarn.lock" \
   snyk/snyk:docker snyk container test \
     $DOCKERUSER/$DOCKERREPO:$APPNAME-$CTAG \
     --file=/app/Dockerfile-$APPNAME \

--- a/bin/scan-container
+++ b/bin/scan-container
@@ -24,10 +24,13 @@ CTAG=${2:-$GITBRANCH}
 THRESHOLD=${3:-low}
 
 # Explicitly turn off DOCKER_CONTENT_TRUST, as snyk are not signing their images.
+# Mount nothing over the yarn.lock file in uswds_ckeditor_integration; we don't install those deps
+# and it throws false positives for us.
 docker run --disable-content-trust -it --rm \
     -e "SNYK_TOKEN=$SNYK_TOKEN" \
     -v /var/run/docker.sock:/var/run/docker.sock \
     -v $(pwd)/.docker:/app \
+    -v "/tmp/nosuchdir:/app/web/modules/contrib/uswds_ckeditor_integration/yarn.lock"
   snyk/snyk:docker snyk container test \
     $DOCKERUSER/$DOCKERREPO:$APPNAME-$CTAG \
     --file=/app/Dockerfile-$APPNAME \

--- a/bin/scan-container
+++ b/bin/scan-container
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # we might be running in circleci
 if [ -f /home/circleci/project/env.local ]; then
@@ -30,7 +30,7 @@ docker run --disable-content-trust -it --rm \
     -e "SNYK_TOKEN=$SNYK_TOKEN" \
     -v /var/run/docker.sock:/var/run/docker.sock \
     -v $(pwd)/.docker:/app \
-    -v "/tmp/nosuchdir:/app/web/modules/contrib/uswds_ckeditor_integration/yarn.lock"
+    -v "/tmp/nosuchdir:/app/web/modules/contrib/uswds_ckeditor_integration/yarn.lock" \
   snyk/snyk:docker snyk container test \
     $DOCKERUSER/$DOCKERREPO:$APPNAME-$CTAG \
     --file=/app/Dockerfile-$APPNAME \


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
## Jira Task

<!--- Provide a link to the Jira ticket -->
https://cm-jira.usa.gov/browse/USAGOV-2408 

## Description
<!--- Summarize the changes made in this pull request, not what it's for. -->
- Update `.docker/.snyk` with a clause to silence an alert for SNYK-JS-MOCHA-2863123, specifically within the `@ckeditor/ckeditor5-dev-utils` package. 
- Change shebang to `bin/bash` in `bin/scan-container`

Snyk is producing this alert based on the `yarn.lock` file in the `uswds_ckeditor5_integration` drupal module. I confirmed that the regular expression cited in the vulnerability is not present in the javascript files in this module. 

## Type of Changes
<!--- Put an `x` in all the boxes that apply. -->
- [ ] New Feature
- [x] Bugfix
- [ ] Frontend (Twig, Sass, JS)
  - Add screenshot showing what it should look like
- [ ] Drupal Config (requires "drush cim")
- [ ] New Modules (requires rebuild)
- [ ] Documentation
- [ ] Infrastructure
  - [ ] CMS
  - [ ] WAF
  - [ ] WWW
  - [ ] Egress
  - [ ] Tools
  - [ ] Cron
- [ ] Other

## Testing Instructions
<!-- This instructions are different from “testing instructions” in Jira – those are typically for Content/UX stakeholders -->
<!-- Not “see Jira” – if they are really the same, copy and paste. -->

### Change Requirements
<!-- Checkboxes to indicate need for changes to some part of the system -->

- [ ] Requires New Documentation (Link: {})
- [ ] Requires New Config
- [ ] Requires New Content

### Validation Steps

Run the scans and examine the output. You can run the scans locally by setting `SNYK_TOKEN` in your environment (I think you can create one on a personal account; if not, check in with me) and running `bin/scan-container cms latest`

That will run the scans on the latest cms image in DockerHub, but it will use your local configuration files to do it. 

(Alternatively, you can examine the output of the "Scan Container" step here: https://app.circleci.com/pipelines/github/usagov/usagov-2021/14103/workflows/66c617c4-a2cb-48ef-812c-0bd224bdbac9/jobs/38726

Expect **not** to see this: 
```
Issues with no direct upgrade or patch:
  ✗ Regular Expression Denial of Service (ReDoS) [High Severity][https://security.snyk.io/vuln/SNYK-JS-MOCHA-2863123] in mocha@7.2.0
    introduced by @ckeditor/ckeditor5-dev-utils@43.0.0 > mocha@7.2.0
```

## Security Review
<!-- Checkboxes to indicate need for review -->

- [ ] Adds/updates software (including a library or Drupal module)
- [ ] Communication with external service
- [ ] Changes permissions or workflow
- [ ] Requires SSPP updates


## Reviewer Reminders

- Reviewed code changes
- Reviewed functionality
- Security review complete or not required

## Post PR Approval Instructions

Follow these steps as soon as you merge the new changes.

1. Go to the [USAGov Circle CI project](https://app.circleci.com/pipelines/github/usagov/usagov-2021).
2. Find the commit of this pull request.
3. Build and deploy the changes.
4. Update the Jira ticket by changing the ticket status to `Review in Test` and add a comment. State whether the change is already visible on [cms-dev.usa.gov](http://cms-dev.usa.gov/) and [beta-dev.usa.gov](http://beta-dev.usa.gov/), or if the deployment is still in process.
