### PR TITLE
USAGOV-2436: Improve is-tome-running script on local end

### DIFF
--- a/scripts/tome-running-check.sh
+++ b/scripts/tome-running-check.sh
@@ -4,11 +4,13 @@ SCRIPT_PATH=$(dirname "$0")
 SCRIPT_NAME=tome-run.sh
 #SCRIPT_PID=$$
 
+sleep 2
 PS_AUX=$(ps aux)
 ALREADY_RUNNING=$(echo "$PS_AUX" | grep $SCRIPT_NAME | wc -l)
 if [ "$ALREADY_RUNNING" -gt "0" ]; then
 
     # Due to potential race-conditions brought up in USAGOV-2436, we will wait, and check again just to confirm
+    sleep 3
     PS_AUX2=$(ps aux)
     ALREADY_RUNNING2=$(echo "$PS_AUX2" | grep $SCRIPT_NAME | wc -l)
     if [ "$ALREADY_RUNNING2" -gt "0" ]; then

--- a/scripts/tome-running-check.sh
+++ b/scripts/tome-running-check.sh
@@ -4,10 +4,16 @@ SCRIPT_PATH=$(dirname "$0")
 SCRIPT_NAME=tome-run.sh
 #SCRIPT_PID=$$
 
-# we should expect to see our process running: so we would expect a count of 1
 PS_AUX=$(ps aux)
 ALREADY_RUNNING=$(echo "$PS_AUX" | grep $SCRIPT_NAME | wc -l)
 if [ "$ALREADY_RUNNING" -gt "0" ]; then
-    exit 0
+
+    # Due to potential race-conditions brought up in USAGOV-2436, we will wait, and check again just to confirm
+    PS_AUX2=$(ps aux)
+    ALREADY_RUNNING2=$(echo "$PS_AUX2" | grep $SCRIPT_NAME | wc -l)
+    if [ "$ALREADY_RUNNING2" -gt "0" ]; then
+
+        exit 0
+    fi
 fi
 exit 1


### PR DESCRIPTION
Improve is-tome-running script on local end

<!--- Provide a link to the Jira ticket -->
https://cm-jira.usa.gov/browse/USAGOV-2436

## Description
Update the script that checks whether Tome is running to verify its result before returning it.

## Type of Changes
<!--- Put an `x` in all the boxes that apply. -->
- [ ] New Feature
- [ ] Bugfix
- [ ] Frontend (Twig, Sass, JS)
- [ ] Drupal Config (requires "drush cim")
- [ ] New Modules (requires rebuild)
- [ ] Documentation
- [x] Infrastructure
- [ ] Other

## Testing Instructions
I think the only way to test this during a deployment? The only other way I can think of is to have a terminal window open that calls this script (and shows its result) in a loop. And then in another terminal window, trigger Tome, and check to ensure there is not lag between the time the process starts and the results shown in the other terminal window.

## Reviewer Reminders

- Reviewed code changes
- Reviewed functionality
- Security review complete or not required

## Post PR Approval Instructions

Follow these steps as soon as you merge the new changes.

1. Go to the [USAGov Circle CI project](https://app.circleci.com/pipelines/github/usagov/usagov-2021).
2. Find the commit of this pull request.
3. Build and deploy the changes.
4. Update the Jira ticket by changing the ticket status to `Review in Test` and add a comment. State whether the change is already visible on [cms-dev.usa.gov](http://cms-dev.usa.gov/) and [beta-dev.usa.gov](http://beta-dev.usa.gov/), or if the deployment is still in process.
