### PR TITLE
USAGOV-2449: Force the usage of certain Synk digest

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -448,8 +448,8 @@ jobs:
           when: always
           command: |
             # kill the Snyk Docker images, as we dont want the next scan to waste time scaning them
-            docker image rm snyk/snyk:php
-            docker image rm snyk/snyk:docker
+            docker image rm snyk/snyk:php || true
+            docker image rm snyk/snyk:docker || true
             # build a fresh docker-bench-security container
             cd /tmp/
             git clone --depth 1 https://github.com/docker/docker-bench-security.git

--- a/bin/scan-container
+++ b/bin/scan-container
@@ -23,12 +23,14 @@ CTAG=${2:-$GITBRANCH}
 
 THRESHOLD=${3:-low}
 
+# Force use to use the digest sha256:cebce69ae39e76a71f704f285211ed21b460c645a5996abb632b2636aca8a4ac
+
 # Explicitly turn off DOCKER_CONTENT_TRUST, as snyk are not signing their images.
 docker run --disable-content-trust -it --rm \
     -e "SNYK_TOKEN=$SNYK_TOKEN" \
     -v /var/run/docker.sock:/var/run/docker.sock \
     -v $(pwd)/.docker:/app \
-  snyk/snyk:docker snyk container test \
+  snyk/snyk@sha256:cebce69ae39e76a71f704f285211ed21b460c645a5996abb632b2636aca8a4ac snyk container test \
     $DOCKERUSER/$DOCKERREPO:$APPNAME-$CTAG \
     --file=/app/Dockerfile-$APPNAME \
     --print-deps \


### PR DESCRIPTION
Force the usage of certain Synk digest

<!--- Provide a link to the Jira ticket -->
https://cm-jira.usa.gov/browse/USAGOV-2449

## Description
Using this specific digest when runnning Synk in CircleCI

## Type of Changes
<!--- Put an `x` in all the boxes that apply. -->
- [ ] New Feature
- [ ] Bugfix
- [ ] Frontend (Twig, Sass, JS)
- [ ] Drupal Config (requires "drush cim")
- [ ] New Modules (requires rebuild)
- [ ] Documentation
- [x] Infrastructure
- [ ] Other

## Testing Instructions
You don't need to fully deploy to Dev, we just need to make sure the `build-and-push-container` task runs without crashing.

## Reviewer Reminders

- Reviewed code changes
- Reviewed functionality
- Security review complete or not required

## Post PR Approval Instructions

Follow these steps as soon as you merge the new changes.

1. Go to the [USAGov Circle CI project](https://app.circleci.com/pipelines/github/usagov/usagov-2021).
2. Find the commit of this pull request.
3. Build and deploy the changes.
4. Update the Jira ticket by changing the ticket status to `Review in Test` and add a comment. State whether the change is already visible on [cms-dev.usa.gov](http://cms-dev.usa.gov/) and [beta-dev.usa.gov](http://beta-dev.usa.gov/), or if the deployment is still in process.
