### PR TITLE
USAGOV-2447-v2: Removing redirect for Businessusa.gov

### DIFF
--- a/.docker/src-waf/etc/nginx/snippets/domain-redirects.conf
+++ b/.docker/src-waf/etc/nginx/snippets/domain-redirects.conf
@@ -32,12 +32,8 @@
     return 301 https://www.usa.gov;
   }
 
-  ## Redirect business.usa.gov and businessusa.gov URLs to
+  ## Redirect business.usa.gov URL to
   ## new locations on usa.gov.
-  if ($cf_forwarded_host ~* ^(www\.)?businessusa\.gov$) {
-    set $port 8883;
-    break;
-  }
   if ($cf_forwarded_host ~* ^business\.usa\.gov$) {
     set $port 8883;
     break;

--- a/bin/cloudgov/domains-for-redirects/domains.json
+++ b/bin/cloudgov/domains-for-redirects/domains.json
@@ -7,7 +7,6 @@
         "benefits-tool.usa.gov",
         "blog.gobiernousa.gov",
         "business.usa.gov",
-        "businessusa.gov",
         "citizenscience.gov",
         "www.citizenscience.gov",
         "consumeraction.gov",


### PR DESCRIPTION
Remove businessusa.gov redirect

<!--- Provide a link to the Jira ticket -->
https://cm-jira.usa.gov/browse/USAGOV-2447

## Description
While https://business.usa.gov/ is still a domain registered, https://businessusa.gov/ is not. In here I am removing the businessusa.gov redirect.

## Type of Changes
<!--- Put an `x` in all the boxes that apply. -->
- [ ] New Feature
- [ ] Bugfix
- [ ] Frontend (Twig, Sass, JS)
- [ ] Drupal Config (requires "drush cim")
- [ ] New Modules (requires rebuild)
- [ ] Documentation
- [x] Infrastructure
- [ ] Other

## Post PR Approval Instructions

Follow these steps as soon as you merge the new changes.

1. Go to the [USAGov Circle CI project](https://app.circleci.com/pipelines/github/usagov/usagov-2021).
2. Find the commit of this pull request.
3. Build and deploy the changes.
4. Update the Jira ticket by changing the ticket status to `Review in Test` and add a comment. State whether the change is already visible on [cms-dev.usa.gov](http://cms-dev.usa.gov/) and [beta-dev.usa.gov](http://beta-dev.usa.gov/), or if the deployment is still in process.
