### PR TITLE
USAGOV-2461: Removing placeholder text for search-bar

### DIFF
--- a/web/themes/custom/usagov/components/searchbar/searchbar.twig
+++ b/web/themes/custom/usagov/components/searchbar/searchbar.twig
@@ -6,8 +6,6 @@
       class="{{input_classes}}"
       type="search"
       name="query"
-      placeholder="{{placeholder_string}}"
-      onfocus="this.placeholder"
       autocomplete="off"
   />
   <button class="{{button_classes}}" type="submit">

--- a/web/themes/custom/usagov/templates/block--mobile-navigation.html.twig
+++ b/web/themes/custom/usagov/templates/block--mobile-navigation.html.twig
@@ -10,7 +10,6 @@
     'home_URL': '/es',
     'close': 'Cerrar',
     'search': 'Buscar',
-    'search_placeholder': 'Busque en este sitio...',
     'search_affiliate': usagov_affiliate_es,
     'all_topics': 'Todos los temas y servicios',
     'phone_URL': '/es/llamenos',
@@ -27,7 +26,6 @@
     'home_URL': '/',
     'close': 'Close',
     'search': 'Search',
-    'search_placeholder': 'Search all government',
     'search_affiliate': usagov_affiliate,
     'all_topics': 'All topics and services',
     'phone_URL': '/phone',
@@ -166,7 +164,6 @@
           alt_string,
         } %}
           {% set form_id = translations.form_id %}
-          {% set placeholder_string = translations.search_placeholder %}
           {% set value_string = translations.search_affiliate %}
           {% set label_string = translations.search %}
           {% set alt_string = translations.search %}

--- a/web/themes/custom/usagov/templates/top_nav.html.twig
+++ b/web/themes/custom/usagov/templates/top_nav.html.twig
@@ -45,7 +45,6 @@
 				value_string: usagov_affiliate_lang,
 				input_id:"search-field-small",
 				input_classes:"usa-input text usagov-search-autocomplete ui-autocomplete-input",
-				placeholder_string:"Search all government",
 				button_classes:"usa-button",
 				alt_string:"Search",
 			} %}


### PR DESCRIPTION
Removing 'Search all government' from USA.gov and USA.gov/es/ Search bar
## Jira Task

<!--- Provide a link to the Jira ticket -->
https://cm-jira.usa.gov/browse/USAGOV-2461

## Description
Remove instance of placeholder text for the search-bar as requested.

## Type of Changes
<!--- Put an `x` in all the boxes that apply. -->
- [ ] New Feature
- [ ] Bugfix
- [x] Frontend (Twig, Sass, JS)
- [ ] Drupal Config (requires "drush cim")
- [ ] New Modules (requires rebuild)
- [ ] Documentation
- [ ] Infrastructure
- [ ] Other

## Testing Instructions
Do a `drush cr` and confirm there is no more placeholder or "ghost" text in the search-bar.

## Reviewer Reminders

- Reviewed code changes
- Reviewed functionality
- Security review complete or not required

## Post PR Approval Instructions

Follow these steps as soon as you merge the new changes.

1. Go to the [USAGov Circle CI project](https://app.circleci.com/pipelines/github/usagov/usagov-2021).
2. Find the commit of this pull request.
3. Build and deploy the changes.
4. Update the Jira ticket by changing the ticket status to `Review in Test` and add a comment. State whether the change is already visible on [cms-dev.usa.gov](http://cms-dev.usa.gov/) and [beta-dev.usa.gov](http://beta-dev.usa.gov/), or if the deployment is still in process.
