### PR TITLE
USAGOV-2482: Add temporary redirects for search -> digital

### DIFF
--- a/.docker/src-waf/etc/nginx/snippets/domain-redirects.conf
+++ b/.docker/src-waf/etc/nginx/snippets/domain-redirects.conf
@@ -169,3 +169,13 @@
     set $port 8890;
     break;
   }
+
+  ## www.search.gov and search.gov, temporary until we can get this hosted in digital.gov's infra
+  if ($cf_forwarded_host ~* ^(www\.)?search\.gov$) {
+    return 301 https://digital.gov/guides/search;
+  }
+
+  ## Temporary TEST configuration for above redirects with a throw-away subdomain
+  if ($cf_forwarded_host ~* ^(whtnfrvemzeq\.)?search\.gov$) {
+    return 301 https://digital.gov/guides/search;
+  }


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the title above -->
## Jira Task

<!--- Provide a link to the Jira ticket -->
https://cm-jira.usa.gov/browse/USAGOV-2482

## Description
<!--- Summarize the changes made in this pull request, not what it's for. -->

## Type of Changes
<!--- Put an `x` in all the boxes that apply. -->
- [ ] New Feature
- [ ] Bugfix
- [ ] Frontend (Twig, Sass, JS)
  - Add screenshot showing what it should look like
- [ ] Drupal Config (requires "drush cim")
- [ ] New Modules (requires rebuild)
- [ ] Documentation
- [x] Infrastructure
  - [ ] CMS
  - [x] WAF
  - [ ] WWW
  - [ ] Egress
  - [ ] Tools
  - [ ] Cron
- [ ] Other

## Testing Instructions
<!-- This instructions are different from “testing instructions” in Jira – those are typically for Content/UX stakeholders -->
<!-- Not “see Jira” – if they are really the same, copy and paste. -->

### Change Requirements
<!-- Checkboxes to indicate need for changes to some part of the system -->

- [ ] Requires New Documentation (Link: {})
- [ ] Requires New Config
- [ ] Requires New Content

### Validation Steps

N/A

## Security Review
<!-- Checkboxes to indicate need for review -->

- [ ] Adds/updates software (including a library or Drupal module)
- [ ] Communication with external service
- [ ] Changes permissions or workflow
- [ ] Requires SSPP updates


## Reviewer Reminders

- Reviewed code changes
- Reviewed functionality
- Security review complete or not required

## Post PR Approval Instructions

Follow these steps as soon as you merge the new changes.

1. Go to the [USAGov Circle CI project](https://app.circleci.com/pipelines/github/usagov/usagov-2021).
2. Find the commit of this pull request.
3. Build and deploy the changes.
4. Update the Jira ticket by changing the ticket status to `Review in Test` and add a comment. State whether the change is already visible on [cms-dev.usa.gov](http://cms-dev.usa.gov/) and [beta-dev.usa.gov](http://beta-dev.usa.gov/), or if the deployment is still in process.
