### PR TITLE
USAGOV-2489: Change CMS Dockerfile to use alpine:3.22 tag instead of sha

### DIFF
--- a/.docker/Dockerfile-cms
+++ b/.docker/Dockerfile-cms
@@ -104,9 +104,7 @@ RUN npm install --production=false --prefix /var/www/web/themes/custom/usagov \
     && chown -R node:node /var/www/web/themes
 
 ###############################################################
-#FROM alpine:3.22 AS cms
-# The following digest is alpine:3.22.1, I'm not sure why, but on my local I had to use the digest from stopping it from going back to 3.20
-FROM alpine@sha256:4bcff63911fcb4448bd4fdacec207030997caf25e9bea4045fa6c8c44de311d1
+FROM alpine:3.22 AS cms
 
 ARG S6_VERSION
 ENV S6_VERSION=${S6_VERSION:-v2.2.0.3}


### PR DESCRIPTION
Change CMS Dockerfile to use alpine:3.22 tag instead of sha

<!--- Provide a link to the Jira ticket -->
https://cm-jira.usa.gov/browse/USAGOV-2489

## Description
Using Docker tag instead of SHA - was able to see this work after factory resetting Docker-desktop and reinstalling it. The issue I need before must have been some sticky caching.

## Type of Changes
<!--- Put an `x` in all the boxes that apply. -->
- [ ] New Feature
- [ ] Bugfix
- [ ] Frontend (Twig, Sass, JS)
- [ ] Drupal Config (requires "drush cim")
- [ ] New Modules (requires rebuild)
- [ ] Documentation
- [ ] Infrastructure
  - [x] CMS
- [ ] Other

## Testing Instructions
Complete rebuild - `docker compose up`, wait for a bit, and then `docker exec -it cms cat /etc/alpine-release`, expect to see `3.22.1`

## Security Review
<!-- Checkboxes to indicate need for review -->

- [ ] Adds/updates software (including a library or Drupal module)
- [ ] Communication with external service
- [ ] Changes permissions or workflow
- [ ] Requires SSPP updates


## Reviewer Reminders

- Reviewed code changes
- Reviewed functionality
- Security review complete or not required

## Post PR Approval Instructions

Follow these steps as soon as you merge the new changes.

1. Go to the [USAGov Circle CI project](https://app.circleci.com/pipelines/github/usagov/usagov-2021).
2. Find the commit of this pull request.
3. Build and deploy the changes.
4. Update the Jira ticket by changing the ticket status to `Review in Test` and add a comment. State whether the change is already visible on [cms-dev.usa.gov](http://cms-dev.usa.gov/) and [beta-dev.usa.gov](http://beta-dev.usa.gov/), or if the deployment is still in process.
