### PR TITLE
USAGOV-2626-fix-content-lock: add patch to fix locking mechanism so t…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -167,6 +167,9 @@
             "drupal/redis": {
                 "Support TLS for Predis": "https://www.drupal.org/files/issues/2021-11-19/redis-support_tls_on_predis-3004561-37.patch",
                 "Don't rely on presence of redis CONFIG command (disabled in AWS)": "https://www.drupal.org/files/issues/2024-09-25/3173988-28.patch"
+            },
+            "drupal/content_lock": {
+                "Fix preview button and submit button access": "./patches/drupal/content_lock-preview-button-lock-release.patch"
             }
         }
     },

--- a/patches/drupal/content_lock-preview-button-lock-release.patch
+++ b/patches/drupal/content_lock-preview-button-lock-release.patch
@@ -1,0 +1,26 @@
+--- content_lock.module.orig	2026-02-04 14:40:03
++++ content_lock.module	2026-02-04 14:40:13
+@@ -79,7 +79,7 @@
+ 
+   // We act only on edit form, not for a creation of a new entity.
+   if (!is_null($entity->id())) {
+-    foreach (['submit', 'publish'] as $key) {
++    foreach (['submit', 'publish', 'preview'] as $key) {
+       if (isset($form['actions'][$key])) {
+         $form['actions'][$key]['#submit'][] = 'content_lock_form_submit';
+       }
+@@ -136,6 +136,14 @@
+     else {
+       // ContentLock::locking() returns TRUE if the content is locked by the
+       // current user. Add an unlock button only for this user.
++      
++      // When we successfully acquire the lock, ensure submit buttons are accessible
++      foreach (['submit', 'publish', 'preview'] as $key) {
++        if (isset($form['actions'][$key]) && isset($form['actions'][$key]['#access']) && $form['actions'][$key]['#access'] === FALSE) {
++          $form['actions'][$key]['#access'] = TRUE;
++        }
++      }
++      
+       $form['actions']['unlock'] = $lock_service->unlockButton($entity_type, $entity->id(), $entity->language()->getId(), $form_op, \Drupal::request()->query->get('destination'));
+     }
+   }


### PR DESCRIPTION
…hat when the lock is created by the current user it doesn't lock THAT user out

<!--- Provide a general summary of your changes in the title above -->
## Jira Task

<!--- Provide a link to the Jira ticket -->
https://cm-jira.usa.gov/browse/USAGOV-2626

## Description
Added patch to fix bug in content lock module that causes lock to apply to user who created lock--fixes that

## Type of Changes
<!--- Put an `x` in all the boxes that apply. -->
- [ ] New Feature
- [ ] Bugfix
- [ ] Frontend (Twig, Sass, JS)
  - Add screenshot showing what it should look like
- [ ] Drupal Config (requires "drush cim")
- [ ] New Modules (requires rebuild)
- [ ] Documentation
- [ ] Infrastructure
  - [ ] CMS
  - [ ] WAF
  - [ ] WWW
  - [ ] Egress
  - [ ] Tools
  - [ ] Cron
- [ ] Other

## Testing Instructions
Go to a blog post and try to edit, should be able to save.

### Change Requirements
<!-- Checkboxes to indicate need for changes to some part of the system -->

- [ ] Requires New Documentation (Link: {})
- [ ] Requires New Config
- [ ] Requires New Content

### Validation Steps

- Test instruction 1
- Test instruction 2
- Test instruction 3

## Security Review
<!-- Checkboxes to indicate need for review -->

- [ ] Adds/updates software (including a library or Drupal module)
- [ ] Communication with external service
- [ ] Changes permissions or workflow
- [ ] Requires SSPP updates


## Reviewer Reminders

- Reviewed code changes
- Reviewed functionality
- Security review complete or not required

## Post PR Approval Instructions

Follow these steps as soon as you merge the new changes.

1. Go to the [USAGov Circle CI project](https://app.circleci.com/pipelines/github/usagov/usagov-2021).
2. Find the commit of this pull request.
3. Build and deploy the changes.
4. Update the Jira ticket by changing the ticket status to `Review in Test` and add a comment. State whether the change is already visible on [cms-dev.usa.gov](http://cms-dev.usa.gov/) and [beta-dev.usa.gov](http://beta-dev.usa.gov/), or if the deployment is still in process.
