### PR TITLE
USAGOV-2637-update-waf-zlib-1.3.2: updated zlib in waf to 1.3.2

### DIFF
--- a/.docker/Dockerfile-waf
+++ b/.docker/Dockerfile-waf
@@ -65,7 +65,7 @@ RUN apt-get update && \
     pkg-config \
     procps \
     wget \
-    zlib1g-dev 
+    zlib1g-dev
 
 RUN set -eux; \
     mkdir /var/log/modsecurity && \
@@ -111,7 +111,7 @@ COPY src-waf/cert-watcher.sh /cert-watcher.sh
 COPY motd /etc/motd
 
 # Set environment variables
-ENV ZLIB_VERSION=1.3.1
+ENV ZLIB_VERSION=1.3.2
 # Note the /fossils path also includes the latest version.
 ENV ZLIB_SRC_URL=http://www.zlib.net/fossils/zlib-${ZLIB_VERSION}.tar.gz
 RUN wget ${ZLIB_SRC_URL} && \

--- a/.docker/Dockerfile-waf
+++ b/.docker/Dockerfile-waf
@@ -111,10 +111,19 @@ COPY src-waf/cert-watcher.sh /cert-watcher.sh
 COPY motd /etc/motd
 
 # Set environment variables
+# When updating ZLIB_VERSION, also update ZLIB_SHA (SHA-256 of the tar.gz, published at https://www.zlib.net/)
 ENV ZLIB_VERSION=1.3.2
-# Note the /fossils path also includes the latest version.
-ENV ZLIB_SRC_URL=http://www.zlib.net/fossils/zlib-${ZLIB_VERSION}.tar.gz
+ENV ZLIB_SHA=bb329a0a2cd0274d05519d61c667c062e06990d72e125ee2dfa8de64f0119d16
+ENV ZLIB_SRC_URL=https://github.com/madler/zlib/releases/download/v${ZLIB_VERSION}/zlib-${ZLIB_VERSION}.tar.gz
+
+# Warn if a newer zlib version exists
+RUN LATEST=$(curl -s -o /dev/null -w "%{url_effective}" -L https://github.com/madler/zlib/releases/latest | grep -oP 'tag/v\K[^/]+') \
+    && if [ "$LATEST" != "${ZLIB_VERSION}" ]; then \
+        echo "WARNING: zlib ${ZLIB_VERSION} is pinned but latest release is ${LATEST}"; \
+    fi
+
 RUN wget ${ZLIB_SRC_URL} && \
+    echo "${ZLIB_SHA}  zlib-${ZLIB_VERSION}.tar.gz" | sha256sum -c - && \
     tar -xvzf zlib-${ZLIB_VERSION}.tar.gz && \
     cd zlib-${ZLIB_VERSION} && \
     ./configure --prefix=/usr/local && \


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
## Jira Task

<!--- Provide a link to the Jira ticket -->
https://cm-jira.usa.gov/browse/USAGOV-2637

## Description
changed the env variable

## Type of Changes
<!--- Put an `x` in all the boxes that apply. -->
- [ ] New Feature
- [ ] Bugfix
- [ ] Frontend (Twig, Sass, JS)
  - Add screenshot showing what it should look like
- [ ] Drupal Config (requires "drush cim")
- [ ] New Modules (requires rebuild)
- [ ] Documentation
- [ ] Infrastructure
  - [ ] CMS
  - [ ] WAF
  - [ ] WWW
  - [ ] Egress
  - [ ] Tools
  - [ ] Cron
- [ ] Other

## Testing Instructions
Log into the waf box and run `ldconfig -p | grep zlib`.  Should show 1.3.2 as the version.

### Change Requirements
<!-- Checkboxes to indicate need for changes to some part of the system -->

- [ ] Requires New Documentation (Link: {})
- [ ] Requires New Config
- [ ] Requires New Content

### Validation Steps

- Test instruction 1
- Test instruction 2
- Test instruction 3

## Security Review
<!-- Checkboxes to indicate need for review -->

- [ ] Adds/updates software (including a library or Drupal module)
- [ ] Communication with external service
- [ ] Changes permissions or workflow
- [ ] Requires SSPP updates


## Reviewer Reminders

- Reviewed code changes
- Reviewed functionality
- Security review complete or not required

## Post PR Approval Instructions

Follow these steps as soon as you merge the new changes.

1. Go to the [USAGov Circle CI project](https://app.circleci.com/pipelines/github/usagov/usagov-2021).
2. Find the commit of this pull request.
3. Build and deploy the changes.
4. Update the Jira ticket by changing the ticket status to `Review in Test` and add a comment. State whether the change is already visible on [cms-dev.usa.gov](http://cms-dev.usa.gov/) and [beta-dev.usa.gov](http://beta-dev.usa.gov/), or if the deployment is still in process.
