### PR TITLE
Usagov 2655 tome blog menu paths

### DIFF
--- a/web/modules/custom/usagov_ssg_postprocessing/src/EventSubscriber/TomeEventSubscriber.php
+++ b/web/modules/custom/usagov_ssg_postprocessing/src/EventSubscriber/TomeEventSubscriber.php
@@ -271,7 +271,7 @@ class TomeEventSubscriber implements EventSubscriberInterface {
    * add it here to ensure /blog is generated.
    *
    * Also, year and month archive pages (e.g. /blog/2018, /blog/2018/03) are served
-   * by the blog view with contextual filters, so Tome cannot discover them
+   * by the blog view with contextual filters, so Tome cannot reliably discover them
    * automatically. We read the paths directly from the usagov_blog_menu
    * menu link entities — which are only created for years/months that have
    * published content — and register them explicitly.

--- a/web/modules/custom/usagov_ssg_postprocessing/src/EventSubscriber/TomeEventSubscriber.php
+++ b/web/modules/custom/usagov_ssg_postprocessing/src/EventSubscriber/TomeEventSubscriber.php
@@ -264,14 +264,42 @@ class TomeEventSubscriber implements EventSubscriberInterface {
   }
 
   /**
-   * Add blog listing paths to be exported.
+   * Add blog year and month archive paths to be exported.
    *
    * The blog view has optional contextual filters (year/month) which means
    * Tome doesn't automatically discover the base /blog path. We explicitly
-   * add it here to ensure /blog and /es/nuestro-blog are generated.
+   * add it here to ensure /blog is generated.
+   *
+   * Also, year and month archive pages (e.g. /blog/2018, /blog/2018/03) are served
+   * by the blog view with contextual filters, so Tome cannot discover them
+   * automatically. We read the paths directly from the usagov_blog_menu
+   * menu link entities — which are only created for years/months that have
+   * published content — and register them explicitly.
    */
   public function addBlogPaths(CollectPathsEvent $event): void {
-    $event->addPath('/blog', ['language_processed' => TRUE, 'langcode' => 'en']);
+    $metadata = ['language_processed' => TRUE, 'langcode' => 'en'];
+
+    // Add the base /blog path.
+    $event->addPath('/blog', $metadata);
+
+    $links = $this->entityTypeManager
+      ->getStorage('menu_link_content')
+      ->loadByProperties(['menu_name' => 'usagov_blog_menu', 'enabled' => 1]);
+
+    foreach ($links as $link) {
+      /** @var \Drupal\menu_link_content\Entity\MenuLinkContent $link */
+      $uri = $link->get('link')->uri ?? '';
+      // URIs are in the form "internal:/blog/YYYY" or "internal:/blog/YYYY/MM".
+      // Skip node links (individual blog posts) which Tome discovers normally.
+      if (!str_starts_with($uri, 'internal:/blog/')) {
+        continue;
+      }
+      $path = substr($uri, strlen('internal:'));
+      // Only register year (/blog/YYYY) and month (/blog/YYYY/MM) paths.
+      if (preg_match('#^/blog/\d{4}(/\d{2})?$#', $path)) {
+        $event->addPath($path, $metadata);
+      }
+    }
   }
 
   /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
## Jira Task

<!--- Provide a link to the Jira ticket -->
https://cm-jira.usa.gov/browse/USAGOV-2655

## Description
Added to the addBlogPaths subscriber to explicitly get the year/month links from usagov_blog_menu instead of relying on scraping. 

## Type of Changes
<!--- Put an `x` in all the boxes that apply. -->
- [ ] New Feature
- [ ] Bugfix
- [ ] Frontend (Twig, Sass, JS)
  - Add screenshot showing what it should look like
- [ ] Drupal Config (requires "drush cim")
- [ ] New Modules (requires rebuild)
- [ ] Documentation
- [ ] Infrastructure
  - [ ] CMS
  - [ ] WAF
  - [ ] WWW
  - [ ] Egress
  - [ ] Tools
  - [ ] Cron
- [ ] Other

## Testing Instructions
After Tome runs, check that all year/month links in the menu work.

### Change Requirements
<!-- Checkboxes to indicate need for changes to some part of the system -->

- [ ] Requires New Documentation (Link: {})
- [ ] Requires New Config
- [ ] Requires New Content

### Validation Steps

- Test instruction 1
- Test instruction 2
- Test instruction 3

## Security Review
<!-- Checkboxes to indicate need for review -->

- [ ] Adds/updates software (including a library or Drupal module)
- [ ] Communication with external service
- [ ] Changes permissions or workflow
- [ ] Requires SSPP updates


## Reviewer Reminders

- Reviewed code changes
- Reviewed functionality
- Security review complete or not required

## Post PR Approval Instructions

Follow these steps as soon as you merge the new changes.

1. Go to the [USAGov Circle CI project](https://app.circleci.com/pipelines/github/usagov/usagov-2021).
2. Find the commit of this pull request.
3. Build and deploy the changes.
4. Update the Jira ticket by changing the ticket status to `Review in Test` and add a comment. State whether the change is already visible on [cms-dev.usa.gov](http://cms-dev.usa.gov/) and [beta-dev.usa.gov](http://beta-dev.usa.gov/), or if the deployment is still in process.
