### PR TITLE
USAGOV-2674 Use updated action versions for Node 24 compatibility

### DIFF
--- a/.github/workflows/benefits-finder-test.yml
+++ b/.github/workflows/benefits-finder-test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the release branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: "GSA/px-benefit-finder"
           ref: "release" # Specify the branch name here
@@ -32,7 +32,7 @@ jobs:
           git switch ${{ github.ref_name }}
 
       - name: Cypress run (Chrome)
-        uses: cypress-io/github-action@v6
+        uses: cypress-io/github-action@v7
         with:
           working-directory: ./benefit-finder
           browser: chrome
@@ -51,7 +51,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the release branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: "GSA/px-benefit-finder"
           ref: "release" # Specify the branch name here
@@ -72,7 +72,7 @@ jobs:
           git switch ${{ github.ref_name }}
 
       - name: Cypress run (Firefox)
-        uses: cypress-io/github-action@v6
+        uses: cypress-io/github-action@v7
         with:
           working-directory: ./benefit-finder
           browser: firefox
@@ -91,7 +91,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the release branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: "GSA/px-benefit-finder"
           ref: "release" # Specify the branch name here
@@ -112,7 +112,7 @@ jobs:
           git switch ${{ github.ref_name }}
 
       - name: Cypress run (Edge)
-        uses: cypress-io/github-action@v6
+        uses: cypress-io/github-action@v7
         with:
           working-directory: ./benefit-finder
           browser: edge

--- a/.github/workflows/benfits-finder-test-pr.yml
+++ b/.github/workflows/benfits-finder-test-pr.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the release branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: "GSA/px-benefit-finder"
           ref: "release" # Specify the branch name here
@@ -37,7 +37,7 @@ jobs:
           git switch ${{ github.head_ref }}
 
       - name: Cypress run (Chrome)
-        uses: cypress-io/github-action@v6
+        uses: cypress-io/github-action@v7
         with:
           working-directory: ./benefit-finder
           browser: chrome
@@ -57,7 +57,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the release branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: "GSA/px-benefit-finder"
           ref: "release" # Specify the branch name here
@@ -78,7 +78,7 @@ jobs:
           git switch ${{ github.head_ref }}
 
       - name: Cypress run (Firefox)
-        uses: cypress-io/github-action@v6
+        uses: cypress-io/github-action@v7
         with:
           working-directory: ./benefit-finder
           browser: firefox
@@ -98,7 +98,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the release branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: "GSA/px-benefit-finder"
           ref: "release" # Specify the branch name here
@@ -119,7 +119,7 @@ jobs:
           git switch ${{ github.head_ref }}
 
       - name: Cypress run (Edge)
-        uses: cypress-io/github-action@v6
+        uses: cypress-io/github-action@v7
         with:
           working-directory: ./benefit-finder
           browser: edge

--- a/.github/workflows/dr-a11y-regression-tests.yml
+++ b/.github/workflows/dr-a11y-regression-tests.yml
@@ -11,11 +11,11 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Set env
         run: echo "CYPRESS_BASE_URL=https://beta-dr.usa.gov/" >> $GITHUB_ENV
       - name: Cypress run
-        uses: cypress-io/github-action@v6
+        uses: cypress-io/github-action@v7
         with:
           working-directory: automated_tests/e2e-cypress
           spec: cypress/e2e/regression_testing/*.cy.js

--- a/.github/workflows/prod-a11y-regression-tests.yml
+++ b/.github/workflows/prod-a11y-regression-tests.yml
@@ -11,11 +11,11 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Set env
         run: echo "CYPRESS_BASE_URL=https://usa.gov/" >> $GITHUB_ENV
       - name: Cypress run
-        uses: cypress-io/github-action@v6
+        uses: cypress-io/github-action@v7
         with:
           working-directory: automated_tests/e2e-cypress
           spec: cypress/e2e/regression_testing/*.cy.js

--- a/.github/workflows/stage-a11y-regression-tests.yml
+++ b/.github/workflows/stage-a11y-regression-tests.yml
@@ -11,11 +11,11 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Set env
         run: echo "CYPRESS_BASE_URL=https://beta-stage.usa.gov/" >> $GITHUB_ENV
       - name: Cypress run
-        uses: cypress-io/github-action@v6
+        uses: cypress-io/github-action@v7
         with:
           working-directory: automated_tests/e2e-cypress
           spec: cypress/e2e/regression_testing/*.cy.js


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the title above -->
## Jira Task

<!--- Provide a link to the Jira ticket -->
https://gsa-standard.atlassian-us-gov-mod.net/browse/USAGOV-2674

## Description
<!--- Summarize the changes made in this pull request, not what it's for. -->

Updated action yaml files
## Type of Changes
<!--- Put an `x` in all the boxes that apply. -->
- [ ] New Feature
- [ ] Bugfix
- [ ] Frontend (Twig, Sass, JS)
  - Add screenshot showing what it should look like
- [ ] Drupal Config (requires "drush cim")
- [ ] New Modules (requires rebuild)
- [ ] Documentation
- [ ] Infrastructure
  - [ ] CMS
  - [ ] WAF
  - [ ] WWW
  - [ ] Egress
  - [ ] Tools
  - [ ] Cron
- [x] Other

## Validation Steps

Github A11Y regression test actions should not display the error:

```
Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/checkout@v4, cypress-io/github-action@v6.
```
## Security Review
<!-- Checkboxes to indicate need for review -->

- [ ] Adds/updates software (including a library or Drupal module)
- [ ] Communication with external service
- [ ] Changes permissions or workflow
- [ ] Requires SSPP updates


## Reviewer Reminders

- Reviewed code changes
- Reviewed functionality
- Security review complete or not required

## Post PR Approval Instructions

Follow these steps as soon as you merge the new changes.

1. Go to the [USAGov Circle CI project](https://app.circleci.com/pipelines/github/usagov/usagov-2021).
2. Find the commit of this pull request.
3. Build and deploy the changes.
4. Update the Jira ticket by changing the ticket status to `Review in Test` and add a comment. State whether the change is already visible on [cms-dev.usa.gov](http://cms-dev.usa.gov/) and [beta-dev.usa.gov](http://beta-dev.usa.gov/), or if the deployment is still in process.
