### PR TITLE
USAGOV-2676-db-update-automation: added cim x2, unblock root, and reb…

### DIFF
--- a/bin/db-update
+++ b/bin/db-update
@@ -19,3 +19,9 @@ echo "Importing database from $LOCAL_FILE"
 docker compose exec \
   database \
   /bin/bash -c "sed -e 's/utf8mb4_0900_ai_ci/utf8mb4_unicode_ci/g' /app/$LOCAL_FILE | mariadb --protocol=TCP -hlocalhost -P$LOCAL_PORT -uroot -pmysql drupal; mariadb-upgrade --protocol=TCP -hlocalhost -P$LOCAL_PORT -uroot -pmysql"
+
+echo "Applying local config (enables devel and other local-split modules)..."
+bin/drush config:import -y
+bin/drush config:import -y # run twice to ensure all config is imported, including config that depends on other config
+bin/drush user:unblock root # unblock root for local development
+bin/drush cache:rebuild


### PR DESCRIPTION
…uild to db-update so that local is ready to go immediately

<!--- Provide a general summary of your changes in the title above -->
## Jira Task

<!--- Provide a link to the Jira ticket -->
https://gsa-standard.atlassian-us-gov-mod.net/browse/USAGOV-2676

## Description
Adds commands at the end of db-update so that local is ready right after run rather than having to remember to run extra commands.

## Type of Changes
<!--- Put an `x` in all the boxes that apply. -->
- [ ] New Feature
- [ ] Bugfix
- [ ] Frontend (Twig, Sass, JS)
  - Add screenshot showing what it should look like
- [ ] Drupal Config (requires "drush cim")
- [ ] New Modules (requires rebuild)
- [ ] Documentation
- [ ] Infrastructure
  - [ ] CMS
  - [ ] WAF
  - [ ] WWW
  - [ ] Egress
  - [ ] Tools
  - [ ] Cron
- [ ] Other

## Testing Instructions
Run db-update on prod db, see if local loads with no other help.

### Change Requirements
<!-- Checkboxes to indicate need for changes to some part of the system -->

- [ ] Requires New Documentation (Link: {})
- [ ] Requires New Config
- [ ] Requires New Content

### Validation Steps

- Test instruction 1
- Test instruction 2
- Test instruction 3

## Security Review
<!-- Checkboxes to indicate need for review -->

- [ ] Adds/updates software (including a library or Drupal module)
- [ ] Communication with external service
- [ ] Changes permissions or workflow
- [ ] Requires SSPP updates


## Reviewer Reminders

- Reviewed code changes
- Reviewed functionality
- Security review complete or not required

## Post PR Approval Instructions

Follow these steps as soon as you merge the new changes.

1. Go to the [USAGov Circle CI project](https://app.circleci.com/pipelines/github/usagov/usagov-2021).
2. Find the commit of this pull request.
3. Build and deploy the changes.
4. Update the Jira ticket by changing the ticket status to `Review in Test` and add a comment. State whether the change is already visible on [cms-dev.usa.gov](http://cms-dev.usa.gov/) and [beta-dev.usa.gov](http://beta-dev.usa.gov/), or if the deployment is still in process.
