### PR TITLE
USAGOV-2667: ensure tome generates blog listing pages

### DIFF
--- a/web/modules/custom/usagov_ssg_postprocessing/src/EventSubscriber/TomeEventSubscriber.php
+++ b/web/modules/custom/usagov_ssg_postprocessing/src/EventSubscriber/TomeEventSubscriber.php
@@ -254,6 +254,7 @@ class TomeEventSubscriber implements EventSubscriberInterface {
 
     // Get the Spanish letters
     $view = Views::getView('federal_agencies');
+
     $view->setDisplay('attachment_2');
 
     $metadata['langcode'] = 'es';
@@ -264,11 +265,25 @@ class TomeEventSubscriber implements EventSubscriberInterface {
   }
 
   /**
+   * Clear the cache for the blog listing. This isn't "collecting paths," but
+   * it is a thing that we want to get done once before we start processing
+   * the blog pages.
+   *
+   * @param CollectPathsEvent $event
+   * @return void
+   */
+  public function clearBlogViewCache(CollectPathsEvent $event): void {
+    $view = Views::getView('blog_menu');
+    $view->storage->invalidateCaches();
+  }
+
+  /**
    * Add blog year and month archive paths to be exported.
    *
    * The blog view has optional contextual filters (year/month) which means
    * Tome doesn't automatically discover the base /blog path. We explicitly
    * add it here to ensure /blog is generated.
+
    *
    * Also, year and month archive pages (e.g. /blog/2018, /blog/2018/03) are served
    * by the blog view with contextual filters, so Tome cannot reliably discover them
@@ -280,6 +295,7 @@ class TomeEventSubscriber implements EventSubscriberInterface {
     $metadata = ['language_processed' => TRUE, 'langcode' => 'en'];
 
     // Add the base /blog path.
+    // TODO: this doesn't seem to be working reliably.
     $event->addPath('/blog', $metadata);
 
     $links = $this->entityTypeManager
@@ -300,6 +316,8 @@ class TomeEventSubscriber implements EventSubscriberInterface {
         $event->addPath($path, $metadata);
       }
     }
+
+    // TODO: also need to force the "page/\d+" directories. Those aren't in the menu.
   }
 
   /**
@@ -327,6 +345,7 @@ class TomeEventSubscriber implements EventSubscriberInterface {
     $events[TomeStaticEvents::MODIFY_HTML][] = ['modifyHtml'];
     $events[TomeStaticEvents::COLLECT_PATHS][] = ['excludeDirectories'];
     $events[TomeStaticEvents::COLLECT_PATHS][] = ['addAgencyIndexes'];
+    $events[TomeStaticEvents::COLLECT_PATHS][] = ['clearBlogViewCache'];
     $events[TomeStaticEvents::COLLECT_PATHS][] = ['addBlogPaths'];
     $events[TomeStaticEvents::PATH_PLACEHOLDER][] = ['excludeInvalidPaths'];
     return $events;

--- a/web/modules/custom/usagov_ssg_postprocessing/src/EventSubscriber/TomeEventSubscriber.php
+++ b/web/modules/custom/usagov_ssg_postprocessing/src/EventSubscriber/TomeEventSubscriber.php
@@ -295,7 +295,6 @@ class TomeEventSubscriber implements EventSubscriberInterface {
     $metadata = ['language_processed' => TRUE, 'langcode' => 'en'];
 
     // Add the base /blog path.
-    // TODO: this doesn't seem to be working reliably.
     $event->addPath('/blog', $metadata);
 
     $links = $this->entityTypeManager
@@ -316,8 +315,6 @@ class TomeEventSubscriber implements EventSubscriberInterface {
         $event->addPath($path, $metadata);
       }
     }
-
-    // TODO: also need to force the "page/\d+" directories. Those aren't in the menu.
   }
 
   /**

--- a/web/modules/custom/usagov_ssg_postprocessing/usagov_ssg_postprocessing.module
+++ b/web/modules/custom/usagov_ssg_postprocessing/usagov_ssg_postprocessing.module
@@ -7,7 +7,7 @@ use Drupal\Core\Entity\EntityInterface;
  * Implements hook_entity_view_alter()
  *
  * From Drupal.org -> "If a module wishes to act on the rendered HTML of the
- * ntity rather than the structured content array, it may use this hook to add
+ * entity rather than the structured content array, it may use this hook to add
  * a #post_render callback."
  *
  * @param array<string, mixed> $build


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
## Jira Task

<!--- Provide a link to the Jira ticket -->
https://gsa-standard.atlassian-us-gov-mod.net/browse/USAGOV-2667

## Description
<!--- Summarize the changes made in this pull request, not what it's for. -->
Adds a Tome event listener that clears the cache(s) for our blog view ("blog_menu" system name). Doing this at the start of a tome run seems to resolve the problem of tome failing to create some of the listing pages.

And I fixed a typo that caught my eye in a nearby file.

## Type of Changes
<!--- Put an `x` in all the boxes that apply. -->
- [ ] New Feature
- [x] Bugfix
- [ ] Frontend (Twig, Sass, JS)
  - Add screenshot showing what it should look like
- [ ] Drupal Config (requires "drush cim")
- [ ] New Modules (requires rebuild)
- [ ] Documentation
- [ ] Infrastructure
  - [ ] CMS
  - [ ] WAF
  - [ ] WWW
  - [ ] Egress
  - [ ] Tools
  - [ ] Cron
- [ ] Other

## Testing Instructions
<!-- This instructions are different from “testing instructions” in Jira – those are typically for Content/UX stakeholders -->
<!-- Not “see Jira” – if they are really the same, copy and paste. -->

### Change Requirements
<!-- Checkboxes to indicate need for changes to some part of the system -->

- [ ] Requires New Documentation (Link: {})
- [ ] Requires New Config
- [ ] Requires New Content

### Validation Steps

1. Stop and re-start your cms container to get the new listeners registered. I'm pretty sure there's a command for this but I don't remember what!
2. Run scripts/tome-static.sh, followed by running scripts/tome-sync.sh, which now includes a check for missing /blogpages, and verify that you don't see a warning about missing pages. Or run scripts/tome-run.sh, which incorporates those two steps and more (and which is not what I've been doing, so I might have missed a detail on that)

## Security Review
<!-- Checkboxes to indicate need for review -->

- [ ] Adds/updates software (including a library or Drupal module)
- [ ] Communication with external service
- [ ] Changes permissions or workflow
- [ ] Requires SSPP updates


## Reviewer Reminders

- Reviewed code changes
- Reviewed functionality
- Security review complete or not required

## Post PR Approval Instructions

Follow these steps as soon as you merge the new changes.

1. Go to the [USAGov Circle CI project](https://app.circleci.com/pipelines/github/usagov/usagov-2021).
3. Find the commit of this pull request.
4. Build and deploy the changes.
5. Update the Jira ticket by changing the ticket status to `Review in Test` and add a comment. State whether the change is already visible on [cms-dev.usa.gov](http://cms-dev.usa.gov/) and [beta-dev.usa.gov](http://beta-dev.usa.gov/), or if the deployment is still in process.
