### PR TITLE
USAGOV-2569-remove-config_pages-enable: removed enable lines

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -209,13 +209,6 @@ if [ "${CF_INSTANCE_INDEX:-''}" == "0" ] && [ -z "${SKIP_DRUPAL_BOOTSTRAP:-}" ];
     drush cr
     drush updatedb --no-cache-clear -y
 
-    # USAGOV-1685: One-time fix for config_pages module bootstrap
-    # TODO: Remove this block after all environments (dev/stage/prod) have been deployed once
-    if ! drush pm:list --status=enabled --format=list | grep -q "^config_pages$"; then
-        echo "USAGOV-1685: Enabling config_pages module before first config import..."
-        drush pm:enable config_pages -y
-    fi
-
     drush cim -y || drush cim -y
     drush cim -y
     echo "Notice: If a TXNDATA error is seen above this line, we believe it is likely NewRelic having a connection-reset-by-peer issue. We dont believe this is causing drush-cim to crash."


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
## Jira Task

<!--- Provide a link to the Jira ticket -->
https://gsa-standard.atlassian-us-gov-mod.net/browse/USAGOV-2569

## Description
Removed the lines.  Yep. :)

## Type of Changes
<!--- Put an `x` in all the boxes that apply. -->
- [ ] New Feature
- [ ] Bugfix
- [ ] Frontend (Twig, Sass, JS)
  - Add screenshot showing what it should look like
- [ ] Drupal Config (requires "drush cim")
- [ ] New Modules (requires rebuild)
- [ ] Documentation
- [ ] Infrastructure
  - [ ] CMS
  - [ ] WAF
  - [ ] WWW
  - [ ] Egress
  - [ ] Tools
  - [ ] Cron
- [ ] Other

## Testing Instructions
<!-- This instructions are different from “testing instructions” in Jira – those are typically for Content/UX stakeholders -->
<!-- Not “see Jira” – if they are really the same, copy and paste. -->

### Change Requirements
<!-- Checkboxes to indicate need for changes to some part of the system -->

- [ ] Requires New Documentation (Link: {})
- [ ] Requires New Config
- [ ] Requires New Content

### Validation Steps

- Test instruction 1
- Test instruction 2
- Test instruction 3

## Security Review
<!-- Checkboxes to indicate need for review -->

- [ ] Adds/updates software (including a library or Drupal module)
- [ ] Communication with external service
- [ ] Changes permissions or workflow
- [ ] Requires SSPP updates


## Reviewer Reminders

- Reviewed code changes
- Reviewed functionality
- Security review complete or not required

## Post PR Approval Instructions

Follow these steps as soon as you merge the new changes.

1. Go to the [USAGov Circle CI project](https://app.circleci.com/pipelines/github/usagov/usagov-2021).
2. Find the commit of this pull request.
3. Build and deploy the changes.
4. Update the Jira ticket by changing the ticket status to `Review in Test` and add a comment. State whether the change is already visible on [cms-dev.usa.gov](http://cms-dev.usa.gov/) and [beta-dev.usa.gov](http://beta-dev.usa.gov/), or if the deployment is still in process.
