### PR TITLE
USAGOV-2725 changed the extraction logic to deal with the extra noise in VCAP

### DIFF
--- a/.docker/src-reporter/createreport.sh
+++ b/.docker/src-reporter/createreport.sh
@@ -14,8 +14,23 @@ exec ./local_proxy/caddy run --config ./local_proxy/Caddyfile &
 echo "starting container to create reports"
 
 # SFTWR_AUDIT: emit software versions for monthly security audit log search
-SPACE=$(echo "${VCAP_APPLICATION:-{}}" | jq -r '.space_name // "unknown"')
-APP_NAME=$(echo "${VCAP_APPLICATION:-{}}" | jq -r '.name // "unknown"')
+extract_vcap_application_field() {
+  local field="$1"
+  local value
+
+  value=$(printf '%s' "${VCAP_APPLICATION:-{}}" | jq -r --arg field "$field" '.[$field] // empty' 2>/dev/null)
+
+  # Some Cloud Foundry environments append malformed trailing content, so fall
+  # back to a string extract to keep the audit fields populated without noise.
+  if [ -z "$value" ]; then
+    value=$(printf '%s' "${VCAP_APPLICATION:-{}}" | sed -n "s/.*\"${field}\"[[:space:]]*:[[:space:]]*\"\\([^\"]*\\)\".*/\\1/p" | head -n 1)
+  fi
+
+  printf '%s\n' "${value:-unknown}"
+}
+
+SPACE=$(extract_vcap_application_field "space_name")
+APP_NAME=$(extract_vcap_application_field "name")
 OS_VERSION=$(grep PRETTY_NAME /etc/os-release 2>/dev/null | cut -d'"' -f2 || echo "unknown")
 NODE_V=$(node --version 2>/dev/null | tr -d 'v' || echo "unknown")
 ANALYTICS_REPORTER_V=$(jq -r '.version' /usr/local/lib/node_modules/analytics-reporter/package.json 2>/dev/null || echo "unknown")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
## Jira Task

<!--- Provide a link to the Jira ticket -->
https://gsa-standard.atlassian-us-gov-mod.net/browse/USAGOV-2725

## Description
Changed extraction logic to deal with noisy VCAP

## Type of Changes
<!--- Put an `x` in all the boxes that apply. -->
- [ ] New Feature
- [ ] Bugfix
- [ ] Frontend (Twig, Sass, JS)
  - Add screenshot showing what it should look like
- [ ] Drupal Config (requires "drush cim")
- [ ] New Modules (requires rebuild)
- [ ] Documentation
- [ ] Infrastructure
  - [ ] CMS
  - [ ] WAF
  - [ ] WWW
  - [ ] Egress
  - [ ] Tools
  - [ ] Cron
- [ ] Other

## Testing Instructions
Deploy and logs should not output `ERR jq: parse error: Unmatched '}' at line 1, column 676`.

### Change Requirements
<!-- Checkboxes to indicate need for changes to some part of the system -->

- [ ] Requires New Documentation (Link: {})
- [ ] Requires New Config
- [ ] Requires New Content

### Validation Steps

- Test instruction 1
- Test instruction 2
- Test instruction 3

## Security Review
<!-- Checkboxes to indicate need for review -->

- [ ] Adds/updates software (including a library or Drupal module)
- [ ] Communication with external service
- [ ] Changes permissions or workflow
- [ ] Requires SSPP updates


## Reviewer Reminders

- Reviewed code changes
- Reviewed functionality
- Security review complete or not required

## Post PR Approval Instructions

Follow these steps as soon as you merge the new changes.

1. Go to the [USAGov Circle CI project](https://app.circleci.com/pipelines/github/usagov/usagov-2021).
2. Find the commit of this pull request.
3. Build and deploy the changes.
4. Update the Jira ticket by changing the ticket status to `Review in Test` and add a comment. State whether the change is already visible on [cms-dev.usa.gov](http://cms-dev.usa.gov/) and [beta-dev.usa.gov](http://beta-dev.usa.gov/), or if the deployment is still in process.
