### PR TITLE
USAGOV-2719-AR-punycode-deprication: remove the global install for AR…

### DIFF
--- a/.docker/Dockerfile-reporter
+++ b/.docker/Dockerfile-reporter
@@ -11,8 +11,7 @@ RUN apk upgrade --update \
        gettext \
        ca-certificates
 
-RUN chmod +x /createreport.sh \
-    && npm install -g analytics-reporter
+RUN chmod +x /createreport.sh
 
 WORKDIR /analytics-reporter
 RUN npm install minimist

--- a/.docker/src-reporter/createreport.sh
+++ b/.docker/src-reporter/createreport.sh
@@ -18,7 +18,7 @@ SPACE=$(echo "${VCAP_APPLICATION:-{}}" | jq -r '.space_name // "unknown"')
 APP_NAME=$(echo "${VCAP_APPLICATION:-{}}" | jq -r '.name // "unknown"')
 OS_VERSION=$(grep PRETTY_NAME /etc/os-release 2>/dev/null | cut -d'"' -f2 || echo "unknown")
 NODE_V=$(node --version 2>/dev/null | tr -d 'v' || echo "unknown")
-ANALYTICS_REPORTER_V=$(jq -r '.version' /usr/local/lib/node_modules/analytics-reporter/package.json 2>/dev/null || echo "unknown")
+ANALYTICS_REPORTER_V=$(jq -r '.version' /analytics-reporter/package.json 2>/dev/null || echo "unknown")
 echo "SFTWR_AUDIT: app=${APP_NAME} space=${SPACE} os=\"${OS_VERSION}\" node=${NODE_V} analytics_reporter=${ANALYTICS_REPORTER_V}"
 
 cat ${CF_SYSTEM_CERT_PATH}/* > /etc/combined-certs.pem


### PR DESCRIPTION
… so it no longer requires punycode--also makes the container leaner and less bloated

<!--- Provide a general summary of your changes in the title above -->
## Jira Task

<!--- Provide a link to the Jira ticket -->
https://gsa-standard.atlassian-us-gov-mod.net/browse/USAGOV-2719

## Description
Removed global instal of AR since it was redundant and unnecessary and also happened to solve the punycode require reference.

## Type of Changes
<!--- Put an `x` in all the boxes that apply. -->
- [ ] New Feature
- [ ] Bugfix
- [ ] Frontend (Twig, Sass, JS)
  - Add screenshot showing what it should look like
- [ ] Drupal Config (requires "drush cim")
- [ ] New Modules (requires rebuild)
- [ ] Documentation
- [ ] Infrastructure
  - [ ] CMS
  - [ ] WAF
  - [ ] WWW
  - [ ] Egress
  - [ ] Tools
  - [ ] Cron
- [ ] Other

## Testing Instructions
Deploy and check logs, warning should be gone.

### Change Requirements
<!-- Checkboxes to indicate need for changes to some part of the system -->

- [ ] Requires New Documentation (Link: {})
- [ ] Requires New Config
- [ ] Requires New Content

### Validation Steps

- Test instruction 1
- Test instruction 2
- Test instruction 3

## Security Review
<!-- Checkboxes to indicate need for review -->

- [ ] Adds/updates software (including a library or Drupal module)
- [ ] Communication with external service
- [ ] Changes permissions or workflow
- [ ] Requires SSPP updates


## Reviewer Reminders

- Reviewed code changes
- Reviewed functionality
- Security review complete or not required

## Post PR Approval Instructions

Follow these steps as soon as you merge the new changes.

1. Go to the [USAGov Circle CI project](https://app.circleci.com/pipelines/github/usagov/usagov-2021).
2. Find the commit of this pull request.
3. Build and deploy the changes.
4. Update the Jira ticket by changing the ticket status to `Review in Test` and add a comment. State whether the change is already visible on [cms-dev.usa.gov](http://cms-dev.usa.gov/) and [beta-dev.usa.gov](http://beta-dev.usa.gov/), or if the deployment is still in process.
