### PR TITLE
USAGOV-2691-cloudgov-AI-instructions-usagov-specific:

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -6,12 +6,12 @@ This directory contains task-specific instruction files for AI coding agents wor
 
 | File | Purpose | Applies To |
 |------|---------|------------|
-| `deployment.instructions.md` | CF CLI deployment workflows | `manifest.yml`, deployment scripts |
-| `services.instructions.md` | Service binding and configuration | Service integration code |
-| `manifest.instructions.md` | Manifest file structure | `manifest*.yml` files |
-| `cicd.instructions.md` | CI/CD pipeline setup | `.github/workflows/*.yml` |
-| `security.instructions.md` | Security and compliance | Security-related files |
-| `logging.instructions.md` | Logging and monitoring | Application logging code |
+| `deployment.instructions.md` | CF CLI deployment workflows | `manifest*.yml`, `.cfignore`, `.profile`, `Procfile`, and deploy/bootstrap `*.sh` |
+| `services.instructions.md` | Service binding and configuration | Drupal/PHP files, JS/TS files, Cloud.gov shell scripts, and `manifest*.yml` |
+| `manifest.instructions.md` | Manifest file structure | `manifest*.yml` and `vars*.yml` files |
+| `cicd.instructions.md` | CI/CD pipeline setup | `.github/workflows/*.yml` and `.github/workflows/*.yaml` |
+| `security.instructions.md` | Security and compliance | Drupal/PHP files, JS/TS files, Cloud.gov shell scripts, manifests, and workflow YAML |
+| `logging.instructions.md` | Logging and monitoring | Drupal/PHP files, JS/TS files, Cloud.gov shell scripts, and `manifest*.yml` |
 
 ## File Format
 

--- a/.github/cicd.instructions.md
+++ b/.github/cicd.instructions.md
@@ -1,5 +1,5 @@
 ---
-applyTo: "**/.github/workflows/*.yml,**/.github/workflows/*.yaml,**/Jenkinsfile,**/.circleci/config.yml,**/.travis.yml"
+applyTo: ".github/workflows/*.yml,.github/workflows/*.yaml,**/.github/workflows/*.yml,**/.github/workflows/*.yaml,**/Jenkinsfile,**/.circleci/config.yml,**/.travis.yml"
 ---
 
 # Cloud.gov CI/CD Instructions

--- a/.github/deployment.instructions.md
+++ b/.github/deployment.instructions.md
@@ -1,317 +1,128 @@
 ---
-applyTo: "**/manifest*.yml,**/Procfile,**/.cfignore,**/.profile"
+applyTo: "manifest*.yml,**/manifest*.yml,Procfile,**/Procfile,.cfignore,**/.cfignore,.profile,**/.profile,**/*.sh"
 ---
 
 # Cloud.gov Deployment Instructions
 
-This document provides guidance for deploying applications to cloud.gov using the Cloud Foundry CLI.
+This repository deploys a Drupal application stack to cloud.gov as multiple Cloud Foundry apps. The guidance below is intentionally repo-specific and should be used instead of generic buildpack-first cloud.gov examples.
 
 ## Overview
 
-Cloud.gov uses `cf push` as the primary deployment command. The platform builds your application using buildpacks and runs it in isolated containers.
+- The primary deployment file is `manifest.yml`.
+- The main apps are `cms`, `www`, `waf`, and `cron`.
+- The normal deployment path is Docker-image based, not source-buildpack based.
+- The normal health check pattern in this repo is `health-check-type: process`.
+- Runtime behavior is finalized by shell bootstrap scripts such as `scripts/bootstrap.sh` and `scripts/static-bootstrap.sh`.
 
-## Prerequisites
+## Repo Deployment Model
 
-- Cloud Foundry CLI installed (`cf` command available)
-- Authenticated to cloud.gov: `cf login -a api.fr.cloud.gov --sso`
-- Targeted the correct org and space: `cf target -o <ORG> -s <SPACE>`
+### Main Multi-App Manifest
 
-## Basic Deployment Workflow
-
-### 1. Prepare Your Application
-
-Ensure your application follows these principles:
-
-- **Stateless**: Don't write to local filesystem for persistent data
-- **12-Factor**: Follow [Twelve-Factor App](https://12factor.net/) methodology
-- **Quick startup**: Applications should start within 60 seconds
-- **Health endpoint**: Implement `/health` or similar for monitoring
-
-### 2. Create Required Files
-
-#### manifest.yml
+`manifest.yml` defines the site's main Cloud.gov apps and should be treated as the source of truth for names and service bindings:
 
 ```yaml
----
 applications:
-  - name: my-application
-    memory: 512M
-    instances: 2
-    buildpacks:
-      - python_buildpack
-    env:
-      ENVIRONMENT: production
+  - name: cms
+    docker:
+      image: gsatts/usagov-2021:cms-latest
     services:
-      - my-database
-    routes:
-      - route: my-app.app.cloud.gov
+      - database
+      - secrets
+      - secauthsecrets
+      - storage
+    health-check-type: process
+
+  - name: www
+    docker:
+      image: gsatts/usagov-2021:www-latest
+    services:
+      - secrets
+      - storage
+    health-check-type: process
 ```
 
-#### .cfignore
+- `cms` is the Drupal runtime.
+- `www` is the static-serving app.
+- `waf` is the route-service/WAF app managed with additional helper scripts.
+- `cron` is the no-route background job app with cron-specific service bindings.
 
-Exclude unnecessary files from deployment:
+### Specialized Manifests
 
-```
-.git/
-.gitignore
-node_modules/
-__pycache__/
-*.pyc
-.env
-.env.*
-tests/
-docs/
-*.md
-!README.md
-.vscode/
-.idea/
-```
-
-#### .profile (optional)
-
-Shell script run before app starts:
-
-```bash
-#!/bin/bash
-# Set runtime environment variables
-export APP_STARTED_AT=$(date)
-```
-
-#### Procfile (optional)
-
-Define process types:
-
-```
-web: gunicorn app:app --bind 0.0.0.0:$PORT
-worker: python worker.py
-```
-
-### 3. Deploy the Application
-
-```bash
-# Basic deployment
-cf push
-
-# Deploy with specific manifest
-cf push -f manifest.yml
-
-# Deploy without starting (useful for binding services first)
-cf push --no-start
-
-# Deploy with a specific app name (overrides manifest)
-cf push my-app-name
-```
-
-### 4. Verify Deployment
-
-```bash
-# Check application status
-cf app <APP_NAME>
-
-# View recent logs
-cf logs <APP_NAME> --recent
-
-# Stream live logs
-cf logs <APP_NAME>
-
-# Check application health
-curl https://<APP_NAME>.app.cloud.gov/health
-```
-
-## Deployment Strategies
-
-### Blue-Green Deployment
-
-Zero-downtime deployment by running two versions simultaneously:
-
-```bash
-# Deploy new version with temporary name
-cf push my-app-venerable -f manifest.yml
-
-# Map production route to new version
-cf map-route my-app-venerable app.cloud.gov --hostname my-app
-
-# Unmap route from old version
-cf unmap-route my-app app.cloud.gov --hostname my-app
-
-# Delete old version when confident
-cf delete my-app -f
-
-# Rename new version to production name
-cf rename my-app-venerable my-app
-```
-
-### Rolling Deployment
-
-Built-in rolling updates (CF CLI v7+):
-
-```bash
-cf push my-app --strategy rolling
-```
-
-### Canary Deployment
-
-Route a percentage of traffic to new version:
-
-```bash
-# Deploy canary version
-cf push my-app-canary -f manifest.yml
-
-# Map same route (traffic splits across instances)
-cf map-route my-app-canary app.cloud.gov --hostname my-app
-
-# Monitor canary, then either promote or rollback
-```
-
-## Scaling Applications
-
-### Horizontal Scaling (Instances)
-
-```bash
-# Scale to 3 instances
-cf scale <APP_NAME> -i 3
-
-# Scale to 1 instance (development only)
-cf scale <APP_NAME> -i 1
-```
-
-### Vertical Scaling (Memory/Disk)
-
-```bash
-# Increase memory
-cf scale <APP_NAME> -m 1G
-
-# Increase disk
-cf scale <APP_NAME> -k 2G
-
-# Scale both
-cf scale <APP_NAME> -m 1G -k 2G
-```
-
-**Best Practice**: Use 2+ instances for production to ensure availability during platform updates and restarts.
-
-## Buildpacks
-
-Cloud.gov supports these standard buildpacks:
-
-| Language | Buildpack Name |
-|----------|----------------|
-| Python | `python_buildpack` |
-| Node.js | `nodejs_buildpack` |
-| Ruby | `ruby_buildpack` |
-| Java | `java_buildpack` |
-| Go | `go_buildpack` |
-| PHP | `php_buildpack` |
-| .NET Core | `dotnet_core_buildpack` |
-| Static files | `staticfile_buildpack` |
-| Binary | `binary_buildpack` |
-
-List available buildpacks:
-
-```bash
-cf buildpacks
-```
-
-### Multi-Buildpack Applications
+- `manifest-reporter.yml` is a specialized analytics reporter manifest.
+- `manifest-egress.yml` is the important exception to the Docker-first rule:
+  it uses buildpacks, an internal route, and `command: ./start.sh` for the egress proxy pattern.
 
 ```yaml
 applications:
-  - name: my-app
+  - name: ((proxyname))
+    path: .docker/src-egress
     buildpacks:
-      - nodejs_buildpack
-      - python_buildpack
+      - https://github.com/cloudfoundry/apt-buildpack
+      - binary_buildpack
+    command: ./start.sh
+    health-check-type: process
 ```
 
-## Application Lifecycle Commands
+Do not rewrite the main site manifests to match the egress example. Treat it as a special-purpose pattern.
+
+## Agent Safety Rules
+
+Before suggesting or running mutating Cloud Foundry commands:
+
+- Run `cf target` and identify the active org and space.
+- State which org/space will be affected.
+- If the space is `prod`, treat it as production and call that out explicitly.
+- Get explicit user confirmation before `cf push`, `cf restage`, `cf restart`, `cf scale`, `cf set-env`, route changes, service binding changes, or service updates/deletes.
+- Prefer read-only inspection first: `cf app`, `cf services`, `cf env`, `cf logs --recent`, `cf routes`, `cf target`.
+
+This repo already contains helper scripts that assume the operator understands the current target space. Agents should not improvise around that safety boundary.
+
+## Preferred Workflow
+
+1. Inspect the current target:
+   `cf target`
+2. Read the relevant manifest before proposing changes:
+   `manifest.yml`, `manifest-reporter.yml`, or `manifest-egress.yml`
+3. Use repo helpers when they match the task:
+   - `bin/deploy/check-current-deployment <space>` for current deployment inspection
+   - `bin/cloudgov/deploy-waf` for WAF / route-service deployment behavior
+   - `bin/deploy/includes` for common CF helper logic used by deployment scripts
+4. Verify post-deploy state with app status and recent logs.
+
+### Verification Commands
 
 ```bash
-# Restart application (uses existing droplet)
-cf restart <APP_NAME>
+cf app cms
+cf app www
+cf app waf
+cf app cron
 
-# Restage application (rebuilds with current buildpack)
-cf restage <APP_NAME>
-
-# Stop application
-cf stop <APP_NAME>
-
-# Start stopped application
-cf start <APP_NAME>
-
-# Delete application
-cf delete <APP_NAME>
-
-# Delete without confirmation
-cf delete <APP_NAME> -f
+cf logs cms --recent
+cf logs www --recent
 ```
 
-## Environment Variables
+For deployment comparison in an existing space, prefer the repo helper:
 
 ```bash
-# Set environment variable
-cf set-env <APP_NAME> DATABASE_URL postgres://...
-
-# View all environment variables
-cf env <APP_NAME>
-
-# Unset environment variable
-cf unset-env <APP_NAME> DATABASE_URL
+bin/deploy/check-current-deployment dev
 ```
 
-**Note**: After changing environment variables, restart or restage the application.
+That helper uses `cf ssh` against `cms` and `waf` to inspect the deployed version markers.
 
-## Route Management
+## Runtime Entry Points
 
-```bash
-# Map a route to an application
-cf map-route <APP_NAME> app.cloud.gov --hostname my-app
+The main post-push runtime configuration lives in shell scripts, not in manifest-only env blocks:
 
-# Unmap a route
-cf unmap-route <APP_NAME> app.cloud.gov --hostname my-app
+- `scripts/bootstrap.sh` configures the `cms` runtime from bound services and environment.
+- `scripts/static-bootstrap.sh` configures the static-serving runtime.
+- `scripts/tome-run.sh` and `scripts/tome-sync.sh` depend on Cloud Foundry service bindings and app metadata.
 
-# View routes
-cf routes
+When editing deployment behavior, review the manifest and the relevant bootstrap script together.
 
-# Create a route without mapping
-cf create-route <SPACE> app.cloud.gov --hostname my-app
-```
+## Avoid
 
-## Troubleshooting
-
-### Application Crashes
-
-```bash
-# View crash logs
-cf logs <APP_NAME> --recent
-
-# Check events
-cf events <APP_NAME>
-
-# SSH into running container (if available)
-cf ssh <APP_NAME>
-```
-
-### Common Issues
-
-| Issue | Possible Cause | Solution |
-|-------|----------------|----------|
-| App crashes on start | Missing dependencies | Check buildpack output, verify requirements files |
-| Out of memory | Memory limit too low | Increase memory with `cf scale -m` |
-| Health check fails | App takes too long to start | Configure longer health check timeout |
-| Cannot connect to service | Egress rules blocking | Update space egress settings |
-
-### Health Check Configuration
-
-```yaml
-applications:
-  - name: my-app
-    health-check-type: http
-    health-check-http-endpoint: /health
-    timeout: 180  # seconds to wait for app to start
-```
-
-## References
-
-- [cloud.gov Deployment Documentation](https://docs.cloud.gov/platform/deployment/)
-- [Cloud Foundry Deployment Guide](https://docs.cloudfoundry.org/devguide/deploy-apps/)
-- [Twelve-Factor App](https://12factor.net/)
-- [cloud.gov Production Ready Guide](https://docs.cloud.gov/platform/deployment/production-ready/)
+- Do not assume the repo uses a single-app source-buildpack deployment.
+- Do not introduce `gunicorn`, generic Python worker, or Node buildpack examples into the main deployment path.
+- Do not default to `health-check-type: http`; the main manifests here use `process`.
+- Do not replace `bin/cloudgov/deploy-waf` with ad hoc route-service commands unless the user explicitly wants that refactor.
+- Do not put secrets directly in manifests; see `services.instructions.md` and `security.instructions.md` for binding and secret-handling guidance.

--- a/.github/logging.instructions.md
+++ b/.github/logging.instructions.md
@@ -1,514 +1,109 @@
 ---
-applyTo: "**/*.py,**/*.js,**/*.ts,**/*.rb,**/*.java,**/*.go,**/manifest*.yml"
+applyTo: "**/*.php,**/*.module,**/*.install,**/*.inc,**/*.theme,**/*.profile,**/*.js,**/*.ts,**/*.tsx,**/*.sh,manifest*.yml,**/manifest*.yml"
 ---
 
 # Cloud.gov Logging Instructions
 
-This document provides guidance for implementing logging and monitoring in cloud.gov applications.
+This repository uses a split logging model: shell/bootstrap/container logs go to stdout or stderr, while Drupal application and audit events go through Drupal logger channels. Logging guidance should extend those existing patterns instead of introducing generic logging frameworks from unrelated stacks.
 
 ## Overview
 
-Cloud.gov automatically captures logs written to `stdout` and `stderr`. Applications should:
-- Write all logs to stdout/stderr (not files)
-- Use structured logging (JSON format recommended)
-- Include contextual information for debugging
-- Never log sensitive data (PII, credentials, tokens)
+- Cloud.gov captures process stdout and stderr.
+- Bootstrap and operational scripts in this repo already emit status and warning lines with `echo`.
+- Drupal business and audit events in this repo are commonly written with `\Drupal::logger(...)`.
+- Local and container New Relic setup is configured to write agent and daemon logs to stderr.
+- `config/sync/system.logging.yml` hides end-user PHP errors, so user-facing error display and operator logging are intentionally separate concerns.
 
-## Viewing Logs
+## Repo Logging Model
 
-### Recent Logs
+### 1. Bootstrap and Container Logs
 
-```bash
-# View recent logs (last ~100 lines)
-cf logs my-app --recent
-```
+Use stdout/stderr for deployment, bootstrap, and background-job visibility.
 
-### Stream Live Logs
+Example patterns already in the repo:
 
 ```bash
-# Stream logs in real-time
-cf logs my-app
-
-# Press Ctrl+C to stop streaming
+echo "Deployment: bootstrap starting"
+echo "WARNING: The aws-rds variable is not set in the VCAP_SERVICES ..."
+echo "Checking current deployment in $TARGET_ENV" | toLogs
 ```
 
-### Log Types
+- Keep these messages concise and operationally useful.
+- Include app/space/context when it helps operators understand what failed.
+- Do not move bootstrap logging into file-based loggers.
 
-Cloud.gov provides several log types:
+### 2. Drupal Application and Audit Logs
 
-| Type | Source | Description |
-|------|--------|-------------|
-| `APP` | Application | Your application's stdout/stderr |
-| `RTR` | Router | HTTP request logs |
-| `STG` | Staging | Build/staging process logs |
-| `CELL` | Cell | Container lifecycle events |
-| `API` | Cloud Controller | CF CLI operations |
+Use Drupal logger channels for application-level events.
 
-### Filter Logs
+Repo example:
+
+```php
+\Drupal::logger('usagov_login')->notice(
+  "Role {$role} added to user {$user_performed_on} ({$user_performed_named}) by user {$uid} ({$uname})."
+);
+```
+
+- Use a channel that matches the owning module or subsystem.
+- Prefer `notice`, `warning`, and `error` levels that reflect operational meaning.
+- Include enough context to investigate, but do not log secrets or sensitive raw payloads.
+
+### 3. New Relic and Observability Tooling
+
+The repo's local/container New Relic setup already follows the stdout/stderr rule:
+
+```sh
+-e 's/;\?newrelic.logfile =.*/newrelic.logfile = \/dev\/stderr/'
+-e 's/;\?newrelic.daemon.logfile =.*/newrelic.daemon.logfile = \/dev\/stderr/'
+```
+
+Bootstrap scripts also configure New Relic from runtime environment values such as `NEW_RELIC_LICENSE_KEY` and `NEW_RELIC_APP_NAME`. Keep observability configuration env-driven.
+
+## Log Consumption in Cloud.gov
+
+Use standard Cloud Foundry log inspection against the real app names in this repo:
 
 ```bash
-# View only application logs (grep for APP)
-cf logs my-app --recent | grep "\[APP"
-
-# View only router logs
-cf logs my-app --recent | grep "\[RTR"
+cf logs cms --recent
+cf logs www --recent
+cf logs waf --recent
+cf logs cron --recent
 ```
 
-## Application Logging
-
-### Basic Logging Configuration
-
-#### Python
-
-```python
-import logging
-import sys
-
-# Configure logging to stdout
-logging.basicConfig(
-    level=logging.INFO,
-    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
-    handlers=[logging.StreamHandler(sys.stdout)]
-)
-
-logger = logging.getLogger(__name__)
-
-# Log messages
-logger.info("Application started")
-logger.warning("Something might be wrong")
-logger.error("An error occurred")
-```
-
-#### Node.js
-
-```javascript
-const winston = require('winston');
-
-const logger = winston.createLogger({
-  level: 'info',
-  format: winston.format.combine(
-    winston.format.timestamp(),
-    winston.format.json()
-  ),
-  transports: [
-    new winston.transports.Console()
-  ]
-});
-
-// Log messages
-logger.info('Application started');
-logger.warn('Something might be wrong');
-logger.error('An error occurred');
-```
-
-#### Ruby
-
-```ruby
-require 'logger'
-
-logger = Logger.new(STDOUT)
-logger.level = Logger::INFO
-
-logger.info("Application started")
-logger.warn("Something might be wrong")
-logger.error("An error occurred")
-```
-
-### Structured Logging (Recommended)
-
-Structured JSON logs are easier to parse and analyze:
-
-#### Python with structlog
-
-```python
-import structlog
-import sys
-
-structlog.configure(
-    processors=[
-        structlog.stdlib.filter_by_level,
-        structlog.stdlib.add_logger_name,
-        structlog.stdlib.add_log_level,
-        structlog.processors.TimeStamper(fmt="iso"),
-        structlog.processors.JSONRenderer()
-    ],
-    wrapper_class=structlog.stdlib.BoundLogger,
-    context_class=dict,
-    logger_factory=structlog.PrintLoggerFactory(),
-)
-
-logger = structlog.get_logger()
-
-# Structured logging with context
-logger.info("user_action", 
-    action="login",
-    user_id=12345,
-    ip_address="192.168.1.1"
-)
-```
-
-Output:
-
-```json
-{"event": "user_action", "action": "login", "user_id": 12345, "ip_address": "192.168.1.1", "level": "info", "timestamp": "2024-01-15T10:30:00Z"}
-```
-
-#### Python with python-json-logger
-
-```python
-import logging
-from pythonjsonlogger import jsonlogger
-
-logger = logging.getLogger()
-handler = logging.StreamHandler()
-formatter = jsonlogger.JsonFormatter(
-    '%(timestamp)s %(level)s %(name)s %(message)s'
-)
-handler.setFormatter(formatter)
-logger.addHandler(handler)
-logger.setLevel(logging.INFO)
-
-logger.info("Request processed", extra={
-    "request_id": "abc123",
-    "method": "POST",
-    "path": "/api/users",
-    "status": 201,
-    "duration_ms": 45
-})
-```
-
-#### Node.js with Pino
-
-```javascript
-const pino = require('pino');
-
-const logger = pino({
-  level: process.env.LOG_LEVEL || 'info',
-  timestamp: pino.stdTimeFunctions.isoTime
-});
-
-// Structured logging
-logger.info({
-  event: 'request_processed',
-  method: 'POST',
-  path: '/api/users',
-  status: 201,
-  duration_ms: 45
-});
-```
-
-### Log Levels
-
-Use appropriate log levels:
-
-| Level | When to Use |
-|-------|-------------|
-| `DEBUG` | Detailed diagnostic information |
-| `INFO` | Normal application events |
-| `WARNING` | Unexpected but handled situations |
-| `ERROR` | Errors that need attention |
-| `CRITICAL` | Severe errors, application may crash |
-
-```python
-# Control log level via environment variable
-import os
-log_level = os.environ.get('LOG_LEVEL', 'INFO')
-logging.basicConfig(level=getattr(logging, log_level))
-```
-
-In `manifest.yml`:
-
-```yaml
-applications:
-  - name: my-app
-    env:
-      LOG_LEVEL: INFO  # or DEBUG, WARNING, ERROR
-```
-
-## Request Logging
-
-### Python Flask
-
-```python
-import logging
-import time
-from flask import Flask, request, g
-
-app = Flask(__name__)
-logger = logging.getLogger(__name__)
-
-@app.before_request
-def before_request():
-    g.start_time = time.time()
-    g.request_id = request.headers.get('X-Request-ID', str(uuid.uuid4()))
-
-@app.after_request
-def after_request(response):
-    duration = time.time() - g.start_time
-    logger.info("request", extra={
-        "request_id": g.request_id,
-        "method": request.method,
-        "path": request.path,
-        "status": response.status_code,
-        "duration_ms": round(duration * 1000, 2),
-        "remote_addr": request.headers.get('X-Forwarded-For', request.remote_addr)
-    })
-    return response
-```
-
-### Node.js Express
-
-```javascript
-const morgan = require('morgan');
-const uuid = require('uuid');
-
-// Add request ID
-app.use((req, res, next) => {
-  req.id = req.headers['x-request-id'] || uuid.v4();
-  next();
-});
-
-// JSON request logging
-app.use(morgan((tokens, req, res) => {
-  return JSON.stringify({
-    event: 'request',
-    request_id: req.id,
-    method: tokens.method(req, res),
-    path: tokens.url(req, res),
-    status: parseInt(tokens.status(req, res)),
-    duration_ms: parseFloat(tokens['response-time'](req, res)),
-    remote_addr: req.headers['x-forwarded-for'] || req.ip
-  });
-}));
-```
-
-## Error Logging
-
-### Python Exception Logging
-
-```python
-import logging
-import traceback
-
-logger = logging.getLogger(__name__)
-
-def process_request():
-    try:
-        # Your code here
-        result = risky_operation()
-    except ValueError as e:
-        # Log expected errors at WARNING
-        logger.warning("validation_error", extra={
-            "error_type": "ValueError",
-            "message": str(e)
-        })
-        raise
-    except Exception as e:
-        # Log unexpected errors at ERROR with traceback
-        logger.error("unexpected_error", extra={
-            "error_type": type(e).__name__,
-            "message": str(e),
-            "traceback": traceback.format_exc()
-        })
-        raise
-```
-
-### Node.js Error Logging
-
-```javascript
-app.use((err, req, res, next) => {
-  logger.error({
-    event: 'error',
-    request_id: req.id,
-    error_type: err.name,
-    message: err.message,
-    stack: err.stack,
-    path: req.path,
-    method: req.method
-  });
-  
-  res.status(500).json({ error: 'Internal server error' });
-});
-```
-
-## Health Check Logging
-
-Implement a health endpoint with minimal logging:
-
-```python
-@app.route('/health')
-def health():
-    # Don't log every health check (too noisy)
-    return jsonify({"status": "healthy"}), 200
-
-# Only log health checks at DEBUG level
-@app.after_request
-def conditional_logging(response):
-    if request.path == '/health':
-        logger.debug("health_check", extra={"status": response.status_code})
-    else:
-        # Normal request logging
-        pass
-    return response
-```
-
-## Log Drains (External Logging)
-
-To send logs to an external logging service:
-
-### Create User-Provided Drain
+For deployment confirmation, pair recent logs with:
 
 ```bash
-cf cups my-log-drain -l syslog-tls://logs.example.com:6514
-cf bind-service my-app my-log-drain
-cf restage my-app
+cf app cms
+cf app www
 ```
 
-### Common Log Drain Services
+## Sensitive Data Rules
 
-- **Papertrail**: `syslog-tls://logsN.papertrailapp.com:XXXXX`
-- **Splunk**: `syslog-tls://input.splunk.example.com:6514`
-- **Sumo Logic**: `syslog-tls://endpoint.sumologic.com:6514`
+`NIST 800-53: AU-2 - Event Logging`
+`NIST 800-53: AU-3 - Content of Audit Records`
+`NIST 800-53: AU-12 - Audit Record Generation`
 
-## Security Considerations
+- Never log credentials, tokens, private keys, raw secret payloads, or sensitive personal data.
+- Treat service credentials from `VCAP_SERVICES` and secrets loaded by bootstrap scripts as non-loggable.
+- Keep operator-visible messages informative without dumping raw environment data.
+- For broader secret-handling and transport protections, follow `security.instructions.md`.
 
-### Never Log Sensitive Data
+## Preferred Pattern / Avoid
 
-```python
-# BAD - Never do this!
-logger.info(f"User login: email={email}, password={password}")
-logger.info(f"API call with token: {api_token}")
-logger.info(f"Processing SSN: {ssn}")
+Prefer:
+- `\Drupal::logger('<channel>')->notice()/warning()/error()` for application events
+- stdout/stderr output for shell/bootstrap/deploy/runtime scripts
+- env-driven observability configuration
+- concise messages with enough context to debug the failing subsystem
 
-# GOOD - Log safely
-logger.info("user_login", extra={"user_id": user.id})
-logger.info("api_call", extra={"endpoint": "/users", "status": 200})
-logger.info("record_processed", extra={"record_type": "user_data"})
-```
+Avoid:
+- introducing file-based application loggers
+- pasting generic Python, Ruby, or Node logging framework examples into repo guidance
+- replacing Drupal logger-channel usage with unrelated raw JSON frameworks
+- exposing internal errors to end users; `config/sync/system.logging.yml` sets `error_level: hide`
 
-### Mask Sensitive Fields
+## Cross-References
 
-```python
-SENSITIVE_FIELDS = ['password', 'token', 'api_key', 'secret', 'ssn', 'credit_card']
-
-def sanitize_log_data(data):
-    """Remove or mask sensitive fields from log data"""
-    if isinstance(data, dict):
-        sanitized = {}
-        for key, value in data.items():
-            if any(field in key.lower() for field in SENSITIVE_FIELDS):
-                sanitized[key] = '***REDACTED***'
-            else:
-                sanitized[key] = sanitize_log_data(value)
-        return sanitized
-    return data
-```
-
-### PII Handling
-
-```python
-import hashlib
-
-def anonymize_user_id(user_id):
-    """Create a consistent but anonymous user identifier for logs"""
-    return hashlib.sha256(f"{user_id}-{SALT}".encode()).hexdigest()[:16]
-
-logger.info("user_action", extra={
-    "anonymous_user": anonymize_user_id(user.id),
-    "action": "profile_update"
-})
-```
-
-## Monitoring and Alerts
-
-### Application Metrics
-
-Log key metrics for monitoring:
-
-```python
-import time
-
-def track_operation(operation_name):
-    def decorator(func):
-        def wrapper(*args, **kwargs):
-            start = time.time()
-            try:
-                result = func(*args, **kwargs)
-                duration = time.time() - start
-                logger.info("operation_complete", extra={
-                    "operation": operation_name,
-                    "duration_ms": round(duration * 1000, 2),
-                    "success": True
-                })
-                return result
-            except Exception as e:
-                duration = time.time() - start
-                logger.error("operation_failed", extra={
-                    "operation": operation_name,
-                    "duration_ms": round(duration * 1000, 2),
-                    "success": False,
-                    "error": str(e)
-                })
-                raise
-        return wrapper
-    return decorator
-
-@track_operation("database_query")
-def fetch_user(user_id):
-    return db.query(User).get(user_id)
-```
-
-### Alerting Patterns
-
-Log events that should trigger alerts:
-
-```python
-# High-severity events that should trigger alerts
-logger.critical("database_connection_lost", extra={
-    "database": "primary",
-    "retry_count": 5,
-    "alert": True
-})
-
-logger.error("payment_processing_failed", extra={
-    "transaction_id": tx_id,
-    "error_code": "GATEWAY_TIMEOUT",
-    "alert": True
-})
-```
-
-## Troubleshooting
-
-### No Logs Appearing
-
-1. Ensure logging to stdout/stderr (not files)
-2. Check log level isn't too restrictive
-3. Verify application is running: `cf app my-app`
-
-### Logs Truncated
-
-- Keep individual log lines under 16KB
-- Break large payloads into multiple log entries
-
-### High Log Volume
-
-- Reduce health check logging frequency
-- Use appropriate log levels (DEBUG only when needed)
-- Sample high-frequency events
-
-## Best Practices Summary
-
-1. **Always log to stdout/stderr** - Never write to files
-2. **Use structured JSON format** - Easier to parse and analyze
-3. **Include request context** - Request ID, user ID, timestamps
-4. **Never log sensitive data** - Mask PII, credentials, tokens
-5. **Use appropriate log levels** - INFO for normal, ERROR for problems
-6. **Log actionable information** - Include enough context to debug
-7. **Configure via environment** - LOG_LEVEL in manifest.yml
-8. **Consider log drains** - External services for long-term retention
-
-## References
-
-- [Cloud Foundry Logging](https://docs.cloudfoundry.org/devguide/deploy-apps/streaming-logs.html)
-- [Twelve-Factor App - Logs](https://12factor.net/logs)
-- [Structured Logging](https://www.structlog.org/)
+- For audit and security boundaries, see `security.instructions.md`.
+- For deployment-time operational checks, see `deployment.instructions.md`.
+- For service-binding failures and startup dependency issues, see `services.instructions.md`.

--- a/.github/manifest.instructions.md
+++ b/.github/manifest.instructions.md
@@ -1,5 +1,5 @@
 ---
-applyTo: "**/manifest*.yml,**/vars*.yml"
+applyTo: "manifest*.yml,**/manifest*.yml,vars*.yml,**/vars*.yml"
 ---
 
 # Cloud.gov Manifest Configuration Instructions

--- a/.github/security.instructions.md
+++ b/.github/security.instructions.md
@@ -1,809 +1,124 @@
 ---
-applyTo: "**/*.py,**/*.js,**/*.ts,**/*.rb,**/*.java,**/*.go,**/manifest*.yml,**/.github/workflows/*.yml"
+applyTo: "**/*.php,**/*.module,**/*.install,**/*.inc,**/*.theme,**/*.profile,**/*.js,**/*.ts,**/*.tsx,**/*.sh,manifest*.yml,**/manifest*.yml,.github/workflows/*.yml,.github/workflows/*.yaml,**/.github/workflows/*.yml,**/.github/workflows/*.yaml"
 ---
 
 # Cloud.gov Security Instructions
 
-This document provides security guidance for applications deployed to cloud.gov, including FedRAMP compliance, secrets management, and security best practices.
+This repository relies on cloud.gov inherited controls and repo-managed application controls. Security guidance here should follow the actual Drupal, shell-bootstrap, and route-service patterns already present in the codebase.
 
 ## Overview
 
-Cloud.gov is FedRAMP Moderate authorized (Package ID: F1607067912). This means:
-- You inherit ~60% of NIST SP 800-53 controls
-- The platform handles infrastructure security
-- You are responsible for application-level security
+- Cloud.gov provides the FedRAMP-authorized platform boundary.
+- This repo is responsible for application secrets, trusted-host behavior, service consumption, route-service configuration, and audit visibility.
+- Use the repo's existing service bindings and runtime configuration paths before proposing new ones.
 
-## Shared Responsibility Model
+## Agent Safety Rules
 
-### Cloud.gov Manages (Inherited Controls)
+Before suggesting or running any mutating Cloud Foundry command:
 
-- Physical security of data centers
-- Network infrastructure security
-- Operating system patching
-- Platform vulnerability scanning
-- Encryption of data at rest and in transit
-- Backup of platform infrastructure
+- Inspect `cf target` and state the current org and space.
+- If the space is `prod`, call that out explicitly as production.
+- Require explicit user confirmation before `cf push`, `cf restage`, `cf restart`, `cf scale`, route changes, service binding changes, or secret/config changes.
+- Prefer read-only verification first: `cf app`, `cf services`, `cf env`, `cf logs --recent`.
 
-### You Manage (Customer Controls)
+## Secrets and Credential Handling
 
-- Application code security
-- Application dependencies and patching
-- Access control within your application
-- Secure handling of user data
-- Application-level logging and monitoring
-- Secrets management for your application
+`NIST 800-53: IA-5 - Authenticator Management`
+`NIST 800-53: SC-28 - Protection of Information at Rest`
+`NIST 800-53: CM-6 - Configuration Settings`
 
-### Shared Controls
+- Do not commit secrets to the repository.
+- Do not place secrets in manifest env blocks or `vars*.yml`.
+- Prefer bound services such as `secrets`, `secauthsecrets`, `database`, and `storage`.
+- Treat `web/sites/default/settings.php` and bootstrap scripts as the canonical runtime locations for secret consumption.
 
-- Incident response (platform + application)
-- Security monitoring (platform + application logs)
-- Access management (platform users + service accounts)
+Repo-specific examples:
+- `settings.php` derives Drupal `hash_salt` from the `secrets` binding.
+- `scripts/bootstrap.sh` reads runtime values such as `NEW_RELIC_*` and `CRON_KEY` from `secrets`.
+- `scripts/bootstrap.sh` reads SAML material from `secauthsecrets` and writes runtime files under `/var/www/`.
 
-## Secrets Management
-
-### Never Commit Secrets
-
-**CRITICAL**: Never commit secrets to version control.
-
-Bad (never do this):
-
-```python
-# DO NOT DO THIS
-DATABASE_URL = "postgres://user:password@host:5432/db"
-API_KEY = "sk-1234567890abcdef"
-```
-
-### Use Environment Variables
-
-Good approach - read from environment:
-
-```python
-import os
-
-DATABASE_URL = os.environ.get('DATABASE_URL')
-API_KEY = os.environ.get('API_KEY')
-```
-
-### Use Bound Services
-
-Best approach - read from VCAP_SERVICES:
-
-```python
-import os
-import json
-
-vcap_services = json.loads(os.environ.get('VCAP_SERVICES', '{}'))
-db_credentials = vcap_services.get('aws-rds', [{}])[0].get('credentials', {})
-
-DATABASE_URL = db_credentials.get('uri')
-```
-
-### Set Environment Variables Securely
-
-```bash
-# Set via CF CLI (not in manifest.yml)
-cf set-env my-app SECRET_KEY "your-secret-value"
-cf restage my-app
-```
-
-### Use User-Provided Services for External Secrets
-
-```bash
-# Create a user-provided service with credentials
-cf cups my-api-credentials -p '{"api_key":"secret123","api_url":"https://api.example.com"}'
-
-# Bind to your app
-cf bind-service my-app my-api-credentials
-cf restage my-app
-```
-
-Access in code:
-
-```python
-vcap_services = json.loads(os.environ.get('VCAP_SERVICES', '{}'))
-api_creds = next(
-    (s['credentials'] for s in vcap_services.get('user-provided', [])
-     if s['name'] == 'my-api-credentials'),
-    {}
-)
-```
-
-### Rotate Secrets Regularly
-
-```bash
-# Rotate database credentials
-cf update-service my-database -c '{"rotate_credentials": true}'
-
-# Wait, then rebind
-cf unbind-service my-app my-database
-cf bind-service my-app my-database
-cf restage my-app --strategy rolling
-```
-
-## Egress Control
-
-### Understanding Egress Rules
-
-By default, new spaces have restricted egress (closed-egress):
-- **closed-egress**: No outbound connections (except internal routes)
-- **trusted-local-egress**: Access to cloud.gov brokered services only
-- **public-egress**: Access to public internet
-
-### Check Current Egress Settings
-
-```bash
-# List security groups for your space
-cf security-groups
-
-# View details of a security group
-cf security-group public_networks_egress
-```
-
-### Enable Egress for Services
-
-Most applications need `trusted-local-egress` to access databases:
-
-```bash
-# Enable access to brokered services (as SpaceManager)
-cf bind-security-group trusted_local_networks_egress your-org --space your-space
-```
-
-### Enable Public Internet Access
-
-If your app needs to call external APIs:
-
-```bash
-# Enable public internet egress (as SpaceManager)
-cf bind-security-group public_networks_egress your-org --space your-space
-```
-
-### Production Configuration
-
-Many production apps need both:
-
-```bash
-# Access to databases AND external APIs
-cf bind-security-group trusted_local_networks_egress your-org --space prod
-cf bind-security-group public_networks_egress your-org --space prod
-```
-
-## Authentication & Authorization
-
-### Use cloud.gov Identity Provider
-
-For federal applications requiring authentication:
-
-```bash
-# Create identity provider service
-cf create-service cloud-gov-identity-provider oauth-client my-identity
-
-# Bind to your app
-cf bind-service my-app my-identity
-cf restage my-app
-```
-
-### Implement Proper Session Management
-
-```python
-# Python Flask example
-from flask import Flask, session
-import os
-
-app = Flask(__name__)
-app.secret_key = os.environ.get('SECRET_KEY')
-
-# Use secure session settings
-app.config.update(
-    SESSION_COOKIE_SECURE=True,     # HTTPS only
-    SESSION_COOKIE_HTTPONLY=True,   # No JavaScript access
-    SESSION_COOKIE_SAMESITE='Lax',  # CSRF protection
-    PERMANENT_SESSION_LIFETIME=1800  # 30 minute timeout
-)
-```
-
-### Implement HTTPS Redirects
-
-Cloud.gov terminates TLS at the platform level, but your app should enforce HTTPS:
-
-```python
-# Flask example
-@app.before_request
-def redirect_https():
-    # Check X-Forwarded-Proto header (set by cloud.gov)
-    if request.headers.get('X-Forwarded-Proto') == 'http':
-        url = request.url.replace('http://', 'https://', 1)
-        return redirect(url, code=301)
-```
-
-## Secure Coding Practices
-
-### Input Validation
-
-```python
-from wtforms import Form, StringField, validators
-from bleach import clean
-
-class UserForm(Form):
-    name = StringField('Name', [
-        validators.Length(min=1, max=100),
-        validators.Regexp(r'^[a-zA-Z\s]+$')
-    ])
-    
-    def sanitize(self):
-        self.name.data = clean(self.name.data)
-```
-
-### SQL Injection Prevention
-
-Use parameterized queries:
-
-```python
-# Good - parameterized query
-cursor.execute("SELECT * FROM users WHERE id = %s", (user_id,))
-
-# Bad - string concatenation (vulnerable!)
-# cursor.execute(f"SELECT * FROM users WHERE id = {user_id}")
-```
-
-### XSS Prevention
-
-```python
-# Use auto-escaping templates (Jinja2 does this by default)
-# Explicitly escape when needed
-from markupsafe import escape
-
-safe_output = escape(user_input)
-```
-
-### CSRF Protection
-
-```python
-# Flask-WTF handles this automatically
-from flask_wtf.csrf import CSRFProtect
-
-csrf = CSRFProtect(app)
-```
-
-## Logging Security
-
-### Never Log Sensitive Data
-
-```python
-import logging
-
-logger = logging.getLogger(__name__)
-
-# Good - log event without sensitive data
-logger.info("User login successful", extra={"user_id": user.id})
-
-# Bad - never do this!
-# logger.info(f"User {user.email} logged in with password {password}")
-```
-
-### Mask Sensitive Fields
-
-```python
-def mask_sensitive(data):
-    """Mask sensitive fields in log data"""
-    sensitive_fields = ['password', 'token', 'api_key', 'ssn', 'credit_card']
-    masked = data.copy()
-    for field in sensitive_fields:
-        if field in masked:
-            masked[field] = '***REDACTED***'
-    return masked
-```
-
-### Structure Logs for SIEM Integration
-
-```python
-import json
-import logging
-from datetime import datetime
-
-class JSONFormatter(logging.Formatter):
-    def format(self, record):
-        log_record = {
-            "timestamp": datetime.utcnow().isoformat(),
-            "level": record.levelname,
-            "message": record.getMessage(),
-            "logger": record.name,
-            "app": os.environ.get('VCAP_APPLICATION', {}).get('name', 'unknown')
-        }
-        if hasattr(record, 'user_id'):
-            log_record['user_id'] = record.user_id
-        return json.dumps(log_record)
-```
-
-## Dependency Security
-
-### Keep Dependencies Updated
-
-```bash
-# Python - check for vulnerabilities
-pip install safety
-safety check -r requirements.txt
-
-# Node.js - audit dependencies
-npm audit
-
-# Fix vulnerabilities
-npm audit fix
-```
-
-### Pin Dependency Versions
-
-```
-# requirements.txt - pin versions
-Django==4.2.7
-requests==2.31.0
-psycopg2-binary==2.9.9
-```
-
-### Use Dependabot or Renovate
-
-Create `.github/dependabot.yml`:
+Prefer this manifest style:
 
 ```yaml
-version: 2
-updates:
-  - package-ecosystem: "pip"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 10
+# NIST 800-53: CM-6 - Configuration Settings
+# Bind named services; do not embed credentials in the manifest.
+services:
+  - database
+  - secrets
+  - secauthsecrets
+  - storage
 ```
 
-## Vulnerability Scanning
-
-### Static Application Security Testing (SAST)
-
-Add to CI/CD pipeline:
+Avoid this pattern:
 
 ```yaml
-# GitHub Actions example
-- name: Run security scan
-  uses: github/codeql-action/analyze@v2
-  with:
-    languages: python
+env:
+  DATABASE_PASSWORD: plain-text-secret
+  HASH_SALT: plain-text-secret
 ```
 
-### Container Scanning
+## Trusted Hosts, Authentication Boundaries, and Local Overrides
 
-If using Docker:
+`NIST 800-53: IA-2 - Identification and Authentication`
+`NIST 800-53: CM-6 - Configuration Settings`
 
-```yaml
-- name: Scan container
-  uses: aquasecurity/trivy-action@master
-  with:
-    image-ref: 'my-app:latest'
-    format: 'sarif'
-    output: 'trivy-results.sarif'
+- `web/sites/default/settings.php` derives `trusted_host_patterns` from `VCAP_APPLICATION.space_name`.
+- The Cloud.gov spaces with explicit trusted-host behavior are `dev`, `dr`, `stage`, and `prod`.
+- `web/sites/default/settings.local.php` contains local-only overrides such as localhost trusted hosts and `$settings['usagov_login_local_form'] = 1`.
+- Treat the local login override as a local-development escape hatch only; do not extend it into Cloud.gov spaces without an explicit requirement.
+
+Preferred PHP pattern:
+
+```php
+$cf_application_data = json_decode($_ENV['VCAP_APPLICATION'] ?? '{}', TRUE);
+$space_name = strtolower($cf_application_data['space_name'] ?? '');
+$settings['trusted_host_patterns'] = [];
 ```
 
-## Compliance Documentation
+## Protected Service Communication
 
-### Document Your Controls
+`NIST 800-53: SC-8 - Transmission Confidentiality and Integrity`
+`NIST 800-53: SC-13 - Cryptographic Protection`
+`NIST 800-53: SC-28 - Protection of Information at Rest`
 
-Maintain documentation for:
-- Your System Security Plan (SSP)
-- Control implementation statements
-- Evidence of control operation
+- `settings.php` enables MySQL TLS in Cloud.gov by setting the RDS CA bundle on the Drupal PDO connection.
+- S3FS is configured to use the service-provided `fips_endpoint` and HTTPS.
+- Redis is configured for TLS unless the service credentials indicate local development.
+- When documenting or extending networked service access, preserve those encrypted-transport defaults.
 
-### Inherited Controls
+## Route Service and Egress Patterns
 
-Reference cloud.gov's FedRAMP package (ID: F1607067912) for inherited controls.
+`NIST 800-53: CM-6 - Configuration Settings`
+`NIST 800-53: SC-8 - Transmission Confidentiality and Integrity`
 
-### Customer Controls
+- `manifest-egress.yml` is the repo's buildpack-based internal egress proxy pattern.
+- `bin/cloudgov/deploy-waf` is the repo's authoritative route-service / WAF deployment helper.
+- That script manages route-service setup, app-to-app policy, env updates, and host mapping for protected apps such as `cms` and `www`.
+- Prefer the existing WAF and egress patterns over hand-written CF route-service flows unless the user specifically wants to change that architecture.
 
-Document how your application implements:
-- Access Control (AC family)
-- Audit and Accountability (AU family)
-- Identification and Authentication (IA family)
-- System and Communications Protection (SC family)
+Do not turn this doc into a generic cloud.gov network tutorial. Keep guidance anchored to `manifest-egress.yml` and `bin/cloudgov/deploy-waf`.
 
-## Documenting NIST Controls in Code
+## Validation and Safe Handling
 
-When generating code or configuration files, **always include NIST SP 800-53 control references** in comments and documentation. This supports the Authority to Operate (ATO) process by creating traceable evidence of control implementation.
+`NIST 800-53: SI-10 - Information Input Validation`
 
-### Control Reference Format
+- Parse `VCAP_APPLICATION` and `VCAP_SERVICES` as JSON and validate service names explicitly.
+- Prefer exact checks such as `if ($service['name'] === 'database')` over loose assumptions about service ordering.
+- In shell, prefer `jq` selectors that name the expected service rather than positional access.
+- Do not silently fall back to invented credential shapes when a required binding is missing; fail clearly or use the repo's established warning behavior.
 
-Use this standard format for control references:
+## Audit and Security Visibility
 
-```
-NIST 800-53: <CONTROL-ID> - <CONTROL-NAME>
-```
+`NIST 800-53: AU-2 - Event Logging`
+`NIST 800-53: AU-3 - Content of Audit Records`
+`NIST 800-53: AU-12 - Audit Record Generation`
 
-Examples:
-- `NIST 800-53: AC-2 - Account Management`
-- `NIST 800-53: AU-2 - Audit Events`
-- `NIST 800-53: SC-8 - Transmission Confidentiality and Integrity`
+- Security-relevant application events should use Drupal logger channels or operational stdout/stderr, depending on whether the event is application-level or bootstrap/container-level.
+- Do not log secrets, raw credentials, tokens, private keys, or sensitive personal data.
+- For detailed audit/logging patterns in this repo, follow `logging.instructions.md`.
 
-### Controls by Artifact Type
+## Cross-References
 
-Use this reference to determine which controls apply to different types of code:
-
-| Artifact Type | Relevant Control Families | Common Controls |
-|---------------|---------------------------|------------------|
-| Authentication code | IA (Identification & Auth) | IA-2, IA-5, IA-8 |
-| Authorization/RBAC | AC (Access Control) | AC-2, AC-3, AC-6 |
-| Logging/Audit code | AU (Audit & Accountability) | AU-2, AU-3, AU-6, AU-12 |
-| Input validation | SI (System & Info Integrity) | SI-10, SI-11 |
-| Encryption/TLS | SC (System & Comm Protection) | SC-8, SC-13, SC-28 |
-| Session management | AC, SC | AC-12, SC-23 |
-| Error handling | SI, AU | SI-11, AU-6 |
-| Configuration files | CM (Config Management) | CM-2, CM-6 |
-| CI/CD workflows | SA, CM | SA-10, CM-3 |
-
-### Code Documentation Examples
-
-#### Python Function with Control Documentation
-
-```python
-def authenticate_user(username: str, password: str) -> Optional[User]:
-    """
-    Authenticate a user with username and password.
-    
-    Security Controls:
-        NIST 800-53: IA-2 - Identification and Authentication (Organizational Users)
-        NIST 800-53: IA-5 - Authenticator Management
-        NIST 800-53: AU-2 - Audit Events (login attempts are logged)
-    
-    Args:
-        username: The user's unique identifier
-        password: The user's password (never logged)
-    
-    Returns:
-        User object if authentication succeeds, None otherwise
-    """
-    # Log authentication attempt (but never the password)
-    # NIST 800-53: AU-3 - Content of Audit Records
-    logger.info("auth_attempt", extra={"username": username, "timestamp": datetime.utcnow()})
-    
-    user = User.query.filter_by(username=username).first()
-    if user and user.verify_password(password):
-        # NIST 800-53: AU-2 - Log successful authentication
-        logger.info("auth_success", extra={"user_id": user.id})
-        return user
-    
-    # NIST 800-53: AU-2 - Log failed authentication
-    logger.warning("auth_failure", extra={"username": username})
-    return None
-```
-
-#### JavaScript/Node.js with Control Documentation
-
-```javascript
-/**
- * Validates and sanitizes user input before processing.
- * 
- * Security Controls:
- *   NIST 800-53: SI-10 - Information Input Validation
- *   NIST 800-53: SI-11 - Error Handling
- * 
- * @param {Object} input - Raw user input
- * @returns {Object} Sanitized input object
- * @throws {ValidationError} If input fails validation
- */
-function validateUserInput(input) {
-  // NIST 800-53: SI-10 - Validate input format and content
-  const schema = Joi.object({
-    email: Joi.string().email().required(),
-    name: Joi.string().max(100).pattern(/^[a-zA-Z\s]+$/).required()
-  });
-  
-  const { error, value } = schema.validate(input);
-  
-  if (error) {
-    // NIST 800-53: SI-11 - Generate error messages that don't reveal system info
-    logger.warn('input_validation_failed', { field: error.details[0].path });
-    throw new ValidationError('Invalid input provided');
-  }
-  
-  // NIST 800-53: SI-10 - Sanitize validated input
-  return {
-    email: value.email.toLowerCase().trim(),
-    name: sanitizeHtml(value.name)
-  };
-}
-```
-
-#### Configuration File with Control Documentation
-
-```yaml
-# manifest.yml
-# 
-# Security Controls Implemented:
-#   NIST 800-53: CM-2 - Baseline Configuration
-#   NIST 800-53: CM-6 - Configuration Settings
-#   NIST 800-53: SC-8 - Transmission Confidentiality (HTTPS enforced by platform)
-#   NIST 800-53: SI-2 - Flaw Remediation (buildpack provides patched runtime)
----
-applications:
-  - name: my-secure-app
-    memory: 512M
-    instances: 2  # NIST 800-53: CP-10 - System Recovery and Reconstitution
-    buildpacks:
-      - python_buildpack
-    env:
-      # NIST 800-53: CM-6 - Security configuration settings
-      SECURE_COOKIES: "true"
-      SESSION_TIMEOUT: "1800"
-    services:
-      - my-database  # NIST 800-53: SC-28 - Protection of Information at Rest
-```
-
-#### CI/CD Workflow with Control Documentation
-
-```yaml
-# .github/workflows/deploy.yml
-#
-# Security Controls Implemented:
-#   NIST 800-53: SA-10 - Developer Configuration Management
-#   NIST 800-53: SA-11 - Developer Security Testing
-#   NIST 800-53: CM-3 - Configuration Change Control
-#   NIST 800-53: AU-6 - Audit Review, Analysis, and Reporting
-
-name: Secure Deployment Pipeline
-
-on:
-  push:
-    branches: [main]
-
-jobs:
-  # NIST 800-53: SA-11 - Security testing before deployment
-  security-scan:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      
-      # NIST 800-53: RA-5 - Vulnerability Scanning
-      - name: Dependency vulnerability scan
-        run: |
-          pip install safety
-          safety check -r requirements.txt
-
-  deploy:
-    needs: security-scan
-    runs-on: ubuntu-latest
-    steps:
-      # NIST 800-53: CM-3 - Controlled deployment from approved branch
-      - uses: actions/checkout@v4
-      
-      # NIST 800-53: IA-2 - Service account authentication
-      - name: Deploy to Cloud.gov
-        uses: cloud-gov/cg-cli-tools@main
-        with:
-          cf_username: ${{ secrets.CG_USERNAME }}
-          cf_password: ${{ secrets.CG_PASSWORD }}
-```
-
-#### Database Migration with Control Documentation
-
-```python
-"""
-Database migration: Add audit logging table
-
-Security Controls:
-    NIST 800-53: AU-3 - Content of Audit Records
-    NIST 800-53: AU-9 - Protection of Audit Information  
-    NIST 800-53: AU-12 - Audit Generation
-"""
-
-def upgrade():
-    # NIST 800-53: AU-3 - Create table to store required audit fields
-    op.create_table(
-        'audit_log',
-        sa.Column('id', sa.Integer(), primary_key=True),
-        sa.Column('timestamp', sa.DateTime(), nullable=False),  # AU-3(a)
-        sa.Column('event_type', sa.String(50), nullable=False),  # AU-3(b)
-        sa.Column('user_id', sa.Integer(), nullable=True),  # AU-3(c)
-        sa.Column('source_ip', sa.String(45), nullable=True),  # AU-3(d)
-        sa.Column('outcome', sa.String(20), nullable=False),  # AU-3(e)
-        sa.Column('details', sa.JSON(), nullable=True)  # AU-3(f)
-    )
-    
-    # NIST 800-53: AU-9 - Protect audit records from modification
-    op.execute("REVOKE UPDATE, DELETE ON audit_log FROM app_user")
-```
-
-### Key Controls Reference
-
-Common NIST SP 800-53 controls to reference in cloud.gov applications:
-
-| Control ID | Control Name | When to Reference |
-|------------|--------------|-------------------|
-| AC-2 | Account Management | User registration, account lifecycle |
-| AC-3 | Access Enforcement | Authorization checks, RBAC |
-| AC-6 | Least Privilege | Role definitions, permission checks |
-| AC-12 | Session Termination | Session timeout, logout |
-| AU-2 | Audit Events | Logging security events |
-| AU-3 | Content of Audit Records | Log record structure |
-| AU-6 | Audit Review | Log analysis, monitoring |
-| AU-12 | Audit Generation | Log generation code |
-| IA-2 | Identification & Authentication | Login, authentication |
-| IA-5 | Authenticator Management | Password handling |
-| SC-8 | Transmission Confidentiality | HTTPS, TLS configuration |
-| SC-13 | Cryptographic Protection | Encryption implementation |
-| SC-28 | Protection of Information at Rest | Database encryption |
-| SI-10 | Information Input Validation | Input validation |
-| SI-11 | Error Handling | Error messages, exception handling |
-| CM-2 | Baseline Configuration | Configuration files |
-| CM-6 | Configuration Settings | Security settings |
-
-## Security Checklist
-
-### Before Deployment
-
-- [ ] No secrets in code or version control
-- [ ] All dependencies pinned and scanned
-- [ ] Input validation implemented
-- [ ] Output encoding for XSS prevention
-- [ ] CSRF protection enabled
-- [ ] Secure session configuration
-- [ ] Logging excludes sensitive data
-
-### Production Configuration
-
-- [ ] Multi-AZ database for redundancy
-- [ ] 2+ application instances
-- [ ] Health check endpoint configured
-- [ ] Egress rules properly configured
-- [ ] Service credentials rotated
-
-### Ongoing
-
-- [ ] Regular dependency updates
-- [ ] Security scanning in CI/CD
-- [ ] Log monitoring configured
-- [ ] Incident response plan documented
-
-## Troubleshooting
-
-### Egress Connection Blocked
-
-**Symptom**: Application cannot reach external API or service
-
-**Diagnosis**:
-```bash
-# Check space egress rules
-cf space <SPACE_NAME> --security-group-rules
-
-# View application logs for connection errors
-cf logs <APP_NAME> --recent | grep -i "connection\|timeout\|refused"
-```
-
-**Solutions**:
-1. Work with cloud.gov support to configure egress rules
-2. Use a cloud.gov-managed service instead of external service
-3. Verify the external service IP/hostname hasn't changed
-
-### Service Credential Access Denied
-
-**Symptom**: Application fails to authenticate to bound service
-
-**Diagnosis**:
-```bash
-# Verify service is bound
-cf services
-
-# Check credentials in environment
-cf env <APP_NAME> | grep -A 20 VCAP_SERVICES
-```
-
-**Solutions**:
-1. Rebind the service: `cf unbind-service <APP> <SERVICE> && cf bind-service <APP> <SERVICE>`
-2. Restage the application: `cf restage <APP_NAME>`
-3. Rotate service credentials if compromised
-
-### Environment Variable Secrets Exposed in Logs
-
-**Symptom**: Sensitive data appearing in `cf logs` output
-
-**Diagnosis**:
-```bash
-# Review recent logs for sensitive patterns
-cf logs <APP_NAME> --recent | grep -i "password\|token\|key\|secret"
-```
-
-**Solutions**:
-1. Update application code to mask sensitive values in logs
-2. Use structured logging with sensitive field filtering
-3. Rotate any exposed credentials immediately
-4. Review log drain destinations for exposure
-
-### Security Group Misconfiguration
-
-**Symptom**: Application cannot communicate with other apps or services
-
-**Diagnosis**:
-```bash
-# List security groups applied to space
-cf security-groups
-
-# Check running security groups
-cf running-security-groups
-
-# Check staging security groups
-cf staging-security-groups
-```
-
-**Solutions**:
-1. Contact cloud.gov support for security group modifications
-2. Verify application is in the correct space
-3. Check if service requires network policy configuration
-
-### SSL/TLS Certificate Errors
-
-**Symptom**: HTTPS connections failing with certificate errors
-
-**Diagnosis**:
-```bash
-# Test connection to external service
-cf ssh <APP_NAME> -c "curl -v https://external-service.example.com"
-```
-
-**Solutions**:
-1. Verify external service certificate is valid and not expired
-2. Check if certificate authority is trusted
-3. For internal services, use service mesh or proper certificate chain
-
-### Session Hijacking Concerns
-
-**Symptom**: Users reporting unexpected session behavior
-
-**Diagnosis**:
-1. Review session configuration for secure flags
-2. Check if sessions are stored externally (Redis) vs in-memory
-3. Verify HTTPS-only access
-
-**Solutions**:
-1. Enable secure and httpOnly cookie flags
-2. Implement session rotation on authentication
-3. Use external session store for multi-instance apps
-4. Configure appropriate session timeout
-
-### Dependency Vulnerability Detected
-
-**Symptom**: Security scanner reports vulnerable dependency
-
-**Diagnosis**:
-```bash
-# Python
-pip-audit
-
-# Node.js
-npm audit
-
-# Ruby
-bundle audit
-```
-
-**Solutions**:
-1. Update vulnerable dependency to patched version
-2. If no patch available, evaluate alternative libraries
-3. Implement compensating controls if update not possible
-4. Document risk acceptance if vulnerability is accepted
-
-### Failed Login Attempts / Brute Force
-
-**Symptom**: High volume of failed authentication attempts
-
-**Diagnosis**:
-```bash
-# Review logs for authentication failures
-cf logs <APP_NAME> --recent | grep -i "auth\|login\|401\|403"
-```
-
-**Solutions**:
-1. Implement rate limiting on authentication endpoints
-2. Add account lockout after failed attempts
-3. Enable multi-factor authentication
-4. Consider WAF or DDoS protection services
-
-## References
-
-- [cloud.gov Compliance Overview](https://docs.cloud.gov/platform/overview/compliance-overview/)
-- [cloud.gov Egress Control](https://docs.cloud.gov/platform/management/space-egress/)
-- [FedRAMP Package Request](https://www.fedramp.gov/resources/documents/Agency_Package_Request_Form.pdf)
-- [OWASP Top 10](https://owasp.org/www-project-top-ten/)
-- [NIST SP 800-53](https://csrc.nist.gov/publications/detail/sp/800-53/rev-5/final)
+- For service-binding and runtime parsing patterns, see `services.instructions.md`.
+- For deployment and manifest behavior, see `deployment.instructions.md`.
+- For logging and observability boundaries, see `logging.instructions.md`.

--- a/.github/services.instructions.md
+++ b/.github/services.instructions.md
@@ -1,455 +1,132 @@
 ---
-applyTo: "**/*.py,**/*.js,**/*.ts,**/*.rb,**/*.java,**/*.go,**/manifest*.yml"
+applyTo: "**/*.php,**/*.module,**/*.install,**/*.inc,**/*.theme,**/*.profile,**/*.js,**/*.ts,**/*.tsx,**/*.sh,manifest*.yml,**/manifest*.yml"
 ---
 
 # Cloud.gov Services Instructions
 
-This document provides guidance for provisioning and using cloud.gov managed services including databases, S3 storage, Redis, and more.
+This repository uses Cloud Foundry service bindings as the primary source of runtime credentials. Service guidance in this repo should be based on the exact binding names and parsing patterns already present in Drupal settings and bootstrap scripts.
 
 ## Overview
 
-Cloud.gov provides managed services through a marketplace. Services are:
-- Created with `cf create-service`
-- Bound to applications to provide credentials
-- Accessed via the `VCAP_SERVICES` environment variable
+- Drupal runtime configuration is built from `VCAP_SERVICES` and `VCAP_APPLICATION` in `web/sites/default/settings.php`.
+- Shell bootstrap scripts such as `scripts/bootstrap.sh`, `scripts/static-bootstrap.sh`, `scripts/tome-run.sh`, and `scripts/tome-sync.sh` parse the same Cloud Foundry JSON with `jq`.
+- When extending this repo, prefer those existing parsing locations instead of inventing new credential-loading paths.
 
-## Listing Available Services
+## Repo Service Names
 
-```bash
-# View all available services
-cf marketplace
+Use the service names already present in the manifests unless the user explicitly asks to change them:
 
-# View plans for a specific service
-cf marketplace -s aws-rds
-cf marketplace -s s3
-```
+| Service Name | Where Used | Notes |
+|-------------|------------|-------|
+| `database` | `cms` | Drupal database binding; credentials become `$databases['default']['default']` in `settings.php` |
+| `storage` | `cms`, `www` | S3-backed storage used by S3FS and static-site sync scripts |
+| `secrets` | `cms`, `www`, `waf` | Hash salt and runtime secrets such as New Relic and cron-related values |
+| `secauthsecrets` | `cms` | SAML-related key/cert material consumed during bootstrap |
+| tagged `cache-service` | optional | Enables Redis caching when a matching service is bound |
+| `cron-state-storage`, `cron-event-storage`, `cron-callwait-storage`, `cron-service-account`, `cron-secrets` | `cron` | Cron-specific runtime services |
+| `AnalyticsReporterServices` | reporter manifest | Specialized reporter service binding |
 
-## Service Lifecycle
+Do not invent alternate binding names in examples when the repo already uses a concrete name.
 
-### Create a Service Instance
+## Where This Repo Reads Cloud Foundry Service Data
 
-```bash
-cf create-service <SERVICE> <PLAN> <INSTANCE_NAME>
-```
+### Drupal Runtime: `settings.php`
 
-### Bind to an Application
+The primary Drupal pattern is:
 
-```bash
-cf bind-service <APP_NAME> <INSTANCE_NAME>
-cf restage <APP_NAME>
-```
+```php
+$cf_application_data = json_decode($_ENV['VCAP_APPLICATION'] ?? '{}', TRUE);
+$cf_service_data = json_decode($_ENV['VCAP_SERVICES'] ?? '{}', TRUE);
 
-### Or Bind via manifest.yml
-
-```yaml
-applications:
-  - name: my-app
-    services:
-      - my-database
-      - my-s3-bucket
-```
-
-### Unbind and Delete
-
-```bash
-cf unbind-service <APP_NAME> <INSTANCE_NAME>
-cf delete-service <INSTANCE_NAME>
-```
-
-## Relational Databases (AWS RDS)
-
-### Available Plans
-
-| Plan | Description |
-|------|-------------|
-| `micro-psql` | Single-AZ PostgreSQL, 1 core, 1 GiB memory |
-| `small-psql` | Single-AZ PostgreSQL, 1 core, 2 GiB memory |
-| `medium-psql` | Single-AZ PostgreSQL, 1 core, 4 GiB memory |
-| `*-psql-redundant` | Multi-AZ PostgreSQL (production recommended) |
-| `small-mysql` | Single-AZ MySQL, 1 core, 2 GiB memory |
-| `*-mysql-redundant` | Multi-AZ MySQL (production recommended) |
-
-**Sandbox spaces**: Only `micro-psql` and `small-mysql` available.
-
-### Create PostgreSQL Database
-
-```bash
-# Development
-cf create-service aws-rds micro-psql my-database
-
-# Production (Multi-AZ)
-cf create-service aws-rds small-psql-redundant my-database
-
-# With custom storage size
-cf create-service aws-rds small-psql my-database -c '{"storage": 50}'
-
-# With specific version
-cf create-service aws-rds micro-psql my-database -c '{"version": "15"}'
-```
-
-### Create MySQL Database
-
-```bash
-cf create-service aws-rds small-mysql my-database
-
-# Enable functions/triggers
-cf create-service aws-rds small-mysql my-database -c '{"enable_functions": true}'
-```
-
-### Database Connection (Python Example)
-
-```python
-import os
-import json
-
-# Parse VCAP_SERVICES
-vcap_services = json.loads(os.environ.get('VCAP_SERVICES', '{}'))
-
-# Get database credentials
-db_credentials = vcap_services.get('aws-rds', [{}])[0].get('credentials', {})
-
-DATABASE_URL = db_credentials.get('uri')
-# Or use individual components:
-DB_HOST = db_credentials.get('host')
-DB_PORT = db_credentials.get('port')
-DB_NAME = db_credentials.get('db_name')
-DB_USER = db_credentials.get('username')
-DB_PASSWORD = db_credentials.get('password')
-```
-
-### Database Connection (Node.js Example)
-
-```javascript
-const cfenv = require('cfenv');
-const appEnv = cfenv.getAppEnv();
-
-// Get database URL
-const dbUrl = appEnv.getServiceURL('my-database');
-
-// Or parse manually
-const vcapServices = JSON.parse(process.env.VCAP_SERVICES || '{}');
-const dbCredentials = vcapServices['aws-rds']?.[0]?.credentials || {};
-
-const dbConfig = {
-  host: dbCredentials.host,
-  port: dbCredentials.port,
-  database: dbCredentials.db_name,
-  user: dbCredentials.username,
-  password: dbCredentials.password,
-  ssl: { rejectUnauthorized: false }
-};
-```
-
-### Rotate Database Credentials
-
-```bash
-# Rotate credentials
-cf update-service my-database -c '{"rotate_credentials": true}'
-
-# Wait, then rebind
-cf unbind-service my-app my-database
-# Wait 1 minute
-cf bind-service my-app my-database
-cf restage my-app --strategy rolling
-```
-
-### Connect to Database Locally
-
-```bash
-# Using cf-service-connect plugin
-cf connect-to-service my-app my-database
-
-# This opens psql/mysql shell directly
-```
-
-## S3 Object Storage
-
-### Available Plans
-
-| Plan | Description |
-|------|-------------|
-| `basic` | Private bucket |
-| `basic-public` | Public read bucket |
-| `basic-sandbox` | Private bucket (deleted with service) |
-| `basic-public-sandbox` | Public bucket (deleted with service) |
-
-### Create S3 Bucket
-
-```bash
-# Private bucket
-cf create-service s3 basic my-s3-bucket
-
-# Public bucket
-cf create-service s3 basic-public my-public-bucket
-```
-
-### S3 Connection (Python Example)
-
-```python
-import os
-import json
-import boto3
-
-vcap_services = json.loads(os.environ.get('VCAP_SERVICES', '{}'))
-s3_credentials = vcap_services.get('s3', [{}])[0].get('credentials', {})
-
-s3_client = boto3.client(
-    's3',
-    aws_access_key_id=s3_credentials.get('access_key_id'),
-    aws_secret_access_key=s3_credentials.get('secret_access_key'),
-    region_name=s3_credentials.get('region')
-)
-
-bucket_name = s3_credentials.get('bucket')
-
-# Upload file
-s3_client.upload_file('local_file.txt', bucket_name, 'remote_file.txt')
-
-# Download file
-s3_client.download_file(bucket_name, 'remote_file.txt', 'local_file.txt')
-
-# List objects
-response = s3_client.list_objects_v2(Bucket=bucket_name)
-```
-
-### S3 Connection (Node.js Example)
-
-```javascript
-const { S3Client, PutObjectCommand, GetObjectCommand } = require('@aws-sdk/client-s3');
-
-const vcapServices = JSON.parse(process.env.VCAP_SERVICES || '{}');
-const s3Creds = vcapServices['s3']?.[0]?.credentials || {};
-
-const s3Client = new S3Client({
-  region: s3Creds.region,
-  credentials: {
-    accessKeyId: s3Creds.access_key_id,
-    secretAccessKey: s3Creds.secret_access_key
+foreach ($cf_service_data as $service_list) {
+  foreach ($service_list as $service) {
+    if ($service['name'] === 'database') {
+      // Configure Drupal DB connection.
+    }
+    elseif ($service['name'] === 'storage') {
+      // Configure S3FS.
+    }
   }
-});
-
-const bucketName = s3Creds.bucket;
-
-// Upload
-await s3Client.send(new PutObjectCommand({
-  Bucket: bucketName,
-  Key: 'my-file.txt',
-  Body: 'Hello, world!'
-}));
-```
-
-### Create Service Key for External Access
-
-```bash
-# Create key
-cf create-service-key my-s3-bucket external-access
-
-# View credentials
-cf service-key my-s3-bucket external-access
-
-# Delete key when done
-cf delete-service-key my-s3-bucket external-access
-```
-
-## Redis (ElastiCache)
-
-### Create Redis Instance
-
-```bash
-cf create-service aws-elasticache-redis redis-dev my-redis
-```
-
-### Redis Connection (Python Example)
-
-```python
-import os
-import json
-import redis
-
-vcap_services = json.loads(os.environ.get('VCAP_SERVICES', '{}'))
-redis_credentials = vcap_services.get('aws-elasticache-redis', [{}])[0].get('credentials', {})
-
-redis_client = redis.from_url(redis_credentials.get('uri'))
-
-# Use Redis
-redis_client.set('key', 'value')
-value = redis_client.get('key')
-```
-
-### Redis Connection (Node.js Example)
-
-```javascript
-const Redis = require('ioredis');
-
-const vcapServices = JSON.parse(process.env.VCAP_SERVICES || '{}');
-const redisCreds = vcapServices['aws-elasticache-redis']?.[0]?.credentials || {};
-
-const redis = new Redis(redisCreds.uri);
-
-await redis.set('key', 'value');
-const value = await redis.get('key');
-```
-
-## User-Provided Services
-
-For external services not in the marketplace:
-
-### Create User-Provided Service
-
-```bash
-# Interactive
-cf create-user-provided-service my-external-api -p "api_key, api_url"
-
-# With JSON
-cf cups my-external-api -p '{"api_key":"secret123","api_url":"https://api.example.com"}'
-```
-
-### Bind to Application
-
-```bash
-cf bind-service my-app my-external-api
-cf restage my-app
-```
-
-### Access in Application
-
-```python
-vcap_services = json.loads(os.environ.get('VCAP_SERVICES', '{}'))
-external_api = vcap_services.get('user-provided', [{}])[0].get('credentials', {})
-
-api_key = external_api.get('api_key')
-api_url = external_api.get('api_url')
-```
-
-## Service Keys
-
-Create credentials for external access (CI/CD, local development):
-
-```bash
-# Create service key
-cf create-service-key my-database deploy-key
-
-# View credentials
-cf service-key my-database deploy-key
-
-# Delete service key
-cf delete-service-key my-database deploy-key
-```
-
-## Sharing Services Between Spaces
-
-```bash
-# Share service with another space
-cf share-service my-database -s other-space
-
-# Share with space in different org
-cf share-service my-database -s other-space -o other-org
-
-# Unshare
-cf unshare-service my-database -s other-space
-```
-
-## Viewing Service Information
-
-```bash
-# List services in current space
-cf services
-
-# View service details
-cf service my-database
-
-# View bound app credentials
-cf env my-app
-```
-
-## VCAP_SERVICES Structure
-
-The `VCAP_SERVICES` environment variable contains all bound service credentials:
-
-```json
-{
-  "aws-rds": [
-    {
-      "name": "my-database",
-      "label": "aws-rds",
-      "plan": "micro-psql",
-      "credentials": {
-        "host": "...",
-        "port": 5432,
-        "db_name": "...",
-        "username": "...",
-        "password": "...",
-        "uri": "postgres://..."
-      }
-    }
-  ],
-  "s3": [
-    {
-      "name": "my-s3-bucket",
-      "credentials": {
-        "access_key_id": "...",
-        "secret_access_key": "...",
-        "bucket": "...",
-        "region": "us-gov-west-1"
-      }
-    }
-  ]
 }
 ```
 
-## Best Practices
+Use this existing parse-once pattern when documenting or extending service consumption in PHP.
 
-### Security
+### Shell Runtime: Bootstrap and Static-Site Scripts
 
-- **Never hardcode credentials** - Always read from `VCAP_SERVICES`
-- **Rotate credentials regularly** - Use `rotate_credentials` for databases
-- **Use service keys sparingly** - Prefer bound credentials when possible
-- **Delete unused service keys** - Reduce credential exposure
-
-### Reliability
-
-- **Use redundant plans for production** - Multi-AZ for databases
-- **Document service dependencies** - Keep manifest.yml updated
-- **Plan for service outages** - Implement retry logic and circuit breakers
-
-### Cost Optimization
-
-- **Right-size services** - Start small, scale as needed
-- **Use sandbox plans for development** - They're deleted automatically
-- **Clean up unused services** - `cf services` to audit
-
-## Troubleshooting
-
-### Cannot Connect to Service
-
-1. Check egress rules: `cf space <SPACE_NAME> --security-group-rules`
-2. Update egress if needed: See [Space Egress](https://docs.cloud.gov/platform/management/space-egress/)
-
-### Service Creation Stuck
+The primary shell pattern is:
 
 ```bash
-# Check service status
-cf service my-database
-
-# View service events
-cf events my-database
+S3_BUCKET=$(echo "$VCAP_SERVICES" | jq -r '.["s3"][]? | select(.name == "storage") | .credentials.bucket')
+SPACE=$(echo "$VCAP_APPLICATION" | jq -r '.["space_name"]')
 ```
 
-### Credentials Not Available
+Use `jq` against the bound service name that already exists in the manifest. Do not introduce parallel `.env` files or hand-maintained secret maps for Cloud.gov runtime credentials.
 
-```bash
-# Verify binding
-cf services
+## Real Data Flow in This Repo
 
-# Rebind if needed
-cf unbind-service my-app my-database
-cf bind-service my-app my-database
-cf restage my-app
+### `database`
+
+- `settings.php` maps the bound `database` service to Drupal's MySQL connection.
+- In Cloud.gov spaces, the DB config also sets the RDS CA bundle for TLS.
+- The DB binding should remain the canonical source of host, port, username, password, and schema name.
+
+```php
+$databases['default']['default'] = [
+  'database' => $service['credentials']['db_name'],
+  'username' => $service['credentials']['username'],
+  'password' => $service['credentials']['password'],
+  'host' => $service['credentials']['host'],
+  'port' => $service['credentials']['port'],
+  'driver' => 'mysql',
+];
 ```
 
-## References
+### `storage`
 
-- [cloud.gov Managed Services](https://docs.cloud.gov/platform/deployment/managed-services/)
-- [RDS Documentation](https://docs.cloud.gov/platform/services/relational-database/)
-- [S3 Documentation](https://docs.cloud.gov/platform/services/s3/)
-- [Cloud Foundry Services](https://docs.cloudfoundry.org/devguide/services/)
+- `settings.php` configures S3FS from the bound `storage` service.
+- `scripts/tome-run.sh` and `scripts/tome-sync.sh` use the same binding for static-site generation and S3 sync.
+- The S3 configuration relies on service-provided `bucket`, `region`, and endpoint values; do not hardcode them.
+
+Relevant repo behavior includes:
+- `root_folder = cms`
+- `public_folder = public`
+- `private_folder = private`
+- `fips_endpoint` for the S3FS hostname
+- `S3_PROXY_PATH_CMS` for the public path exposed through the CMS host
+
+### `secrets` and `secauthsecrets`
+
+- `secrets` provides values such as `HASH_SALT`, `NEW_RELIC_*`, `CRON_KEY`, and other runtime-only secrets used by bootstrap scripts.
+- `secauthsecrets` provides SAML-related certificate and key material that bootstrap writes into runtime files.
+- These services are preferred over manifest env secrets or hardcoded credentials.
+
+### tagged `cache-service`
+
+- Redis is optional and enabled only when `settings.php` sees a bound service whose tags include `cache-service`.
+- When present, the repo prefers TLS for Redis unless the credentials explicitly indicate local development.
+
+## Space-Aware Runtime Configuration
+
+- `VCAP_APPLICATION.space_name` drives `trusted_host_patterns` and config split toggles in `settings.php`.
+- Shell scripts also use the space name to choose the correct public hostname, S3 behavior, and environment-specific logic.
+- When changing service behavior, check both the PHP runtime and shell runtime paths for space-specific logic.
+
+## Preferred Pattern / Avoid
+
+- Prefer parsing Cloud Foundry JSON once in `settings.php` or the relevant bootstrap script.
+- Prefer exact manifest service names such as `database`, `storage`, `secrets`, and `secauthsecrets`.
+- Prefer bound services over manually managed secrets in code or manifests.
+- Prefer extending the existing Drupal + shell runtime patterns instead of introducing parallel config systems.
+
+Avoid:
+- hardcoding database, S3, Redis, or secret credentials
+- inventing alternative service names in examples
+- adding ad hoc credential shapes that do not match `VCAP_SERVICES`
+- duplicating the same service parsing logic in multiple new locations when an existing runtime path already owns it
+
+## Cross-References
+
+- For manifest and deploy behavior, see `deployment.instructions.md`.
+- For secret handling, TLS, and trusted-host guidance, see `security.instructions.md`.
+- For operational logging around service startup and failures, see `logging.instructions.md`.


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the title above -->
## Jira Task

<!--- Provide a link to the Jira ticket -->
https://gsa-standard.atlassian-us-gov-mod.net/browse/USAGOV-2691

## Description
<!--- Summarize the changes made in this pull request, not what it's for. -->

### TL;DR
The AI advice files were originally aimed at generic buildpack oriented cf applications.  The changes in this branch incorporate specifics of our repository (e.g. paths), hybrid (docker+buildpack) deployment processes and Drupal-centric applications.  This allows AI to give better advice when asking for agentic assistance with dev/ops tasks.

For example:  using Codex+GPT5.4, I asked _"Given the content of security.instructions.md - are you able to determine any non-compliance in the PHP files of this repo?"_

The agent put together a list of potential (small) issues with the login form with regard to possibly allowing the default form to be shown.   An interesting/important side effect of this process was that it was able to give specific SSPP control sections for the issues it found.

### Rationale for branch from `USAGOV-2691-cloudgov-AI-instructions`

I noticed that the `applyTo:` preambles of the AI guidance files did not have PHP included, so I had GPT 5.4 read the guidance files and asked it to modify them to support our Drupal/container based system.  Here is the implementation it arrived at:

### GPT 5.4 Implementation for AI Document Customization to USAgov repo

Rewrote the Cloud.gov instruction docs to match this repo's real Drupal + Cloud.gov patterns instead of generic app-platform examples. The changes are limited to `.github/deployment.instructions.md`, `.github/services.instructions.md`, `.github/security.instructions.md`, and `.github/logging.instructions.md`.

The rewritten docs now reference the actual deployment model (`cms`, `www`, `waf`, `cron` in `manifest.yml`), the `manifest-egress.yml` exception path, real deployment helpers in `bin/deploy/*` and `bin/cloudgov/deploy-waf`, actual service bindings like `database`, `storage`, `secrets`, and `secauthsecrets`, Drupal runtime parsing in `web/sites/default/settings.php`, and the repo's real logging/security patterns. Security and logging guidance now includes explicit `NIST 800-53` references.

Validation confirmed the `applyTo` frontmatter remains intact, the docs line up with the current repo sources, and no code, manifests, workflows, or deployment scripts were changed in this pass.

## Type of Changes
<!--- Put an `x` in all the boxes that apply. -->
- [ ] New Feature
- [ ] Bugfix
- [ ] Frontend (Twig, Sass, JS)
  - Add screenshot showing what it should look like
- [ ] Drupal Config (requires "drush cim")
- [ ] New Modules (requires rebuild)
- [x] Documentation
- [ ] Infrastructure
  - [ ] CMS
  - [ ] WAF
  - [ ] WWW
  - [ ] Egress
  - [ ] Tools
  - [ ] Cron
- [ ] Other


## Security Review
<!-- Checkboxes to indicate need for review -->

- [ ] Adds/updates software (including a library or Drupal module)
- [ ] Communication with external service
- [ ] Changes permissions or workflow
- [ ] Requires SSPP updates


## Reviewer Reminders

- Reviewed code changes
- Reviewed functionality
- Security review complete or not required

## Post PR Approval Instructions

Follow these steps as soon as you merge the new changes.

1. Go to the [USAGov Circle CI project](https://app.circleci.com/pipelines/github/usagov/usagov-2021).
2. Find the commit of this pull request.
3. Build and deploy the changes.
4. Update the Jira ticket by changing the ticket status to `Review in Test` and add a comment. State whether the change is already visible on [cms-dev.usa.gov](http://cms-dev.usa.gov/) and [beta-dev.usa.gov](http://beta-dev.usa.gov/), or if the deployment is still in process.
