### PR TITLE
USAGOV-2738-update-nginx-to-1.30.x: updated in cms, www, waf, waf-alp…

### DIFF
--- a/.docker/Dockerfile-cms
+++ b/.docker/Dockerfile-cms
@@ -109,6 +109,9 @@ FROM alpine:3.22 AS cms
 ARG S6_VERSION
 ENV S6_VERSION=${S6_VERSION:-v2.2.0.3}
 
+ARG NGINX_VERSION=1.30.1
+ARG NGINX_SHA512=a081ed49692948ea61bada05a9bade88f9899f843c8d5a72c0d5362e812c14e1ea12de729bcdfe93016323fb014681ddfa472f3352b5e83455991be715293211
+
 ARG GITBRANCH
 ENV GITBRANCH=${GITBRANCH:-none}
 
@@ -299,17 +302,17 @@ RUN cd /tmp/ \
     && wget https://github.com/simpl/ngx_devel_kit/archive/refs/tags/v0.3.1.tar.gz \
     && tar -xzvf v0.3.1.tar.gz \
     && mv ngx_devel_kit-0.3.1 ngx_devel_kit \
-    && wget https://nginx.org/download/nginx-1.28.0.tar.gz \
-    && NGCHECKSUM="07d1ef078a73009c2aff0a5729a57f58f26512b71377715ef72cecdb249ef2ff69dd44df3d755a1de2a2721ee604e8a6cfac30a4cf8a45f0890b1746b68ee4d5 *nginx-1.28.0.tar.gz" \
-    && openssl sha512 -r nginx-1.28.0.tar.gz \
-    && if [ "$(openssl sha512 -r nginx-1.28.0.tar.gz)" = "$NGCHECKSUM" ]; then \
+    && wget https://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz \
+    && NGCHECKSUM="${NGINX_SHA512} *nginx-${NGINX_VERSION}.tar.gz" \
+    && openssl sha512 -r nginx-${NGINX_VERSION}.tar.gz \
+    && if [ "$(openssl sha512 -r nginx-${NGINX_VERSION}.tar.gz)" = "$NGCHECKSUM" ]; then \
         echo "nginx tarball checksum verification succeeded!"; \
-    else \
+      else \
         echo "nginx tarball checksum verification failed!"; \
         exit 1; \
-    fi \
-    && tar -xzvf nginx-1.28.0.tar.gz \
-    && cd nginx-1.28.0 \
+      fi \
+    && tar -xzvf nginx-${NGINX_VERSION}.tar.gz \
+    && cd nginx-${NGINX_VERSION} \
     && ./configure \
         --prefix=/var/lib/nginx \
         --sbin-path=/usr/sbin/nginx \
@@ -326,7 +329,7 @@ RUN cd /tmp/ \
     && make
 RUN rm /etc/nginx/modules/10_devel_kit.conf || true
 RUN rm /etc/nginx/modules/30_http_lua.conf || true
-RUN cd /tmp/nginx-1.28.0 \
+RUN cd /tmp/nginx-${NGINX_VERSION} \
     && make install
 
 # Ensure compatibility if mysqldump has been removed

--- a/.docker/Dockerfile-waf
+++ b/.docker/Dockerfile-waf
@@ -1,7 +1,10 @@
-ARG NGINX_VERSION="1.28.0"
+ARG NGINX_VERSION="1.30.1"
 FROM nginx:${NGINX_VERSION}
 
 LABEL maintainer="USA.gov Web Ops"
+
+ARG NGINX_VERSION=1.30.1
+ARG NGINX_SHA512=a081ed49692948ea61bada05a9bade88f9899f843c8d5a72c0d5362e812c14e1ea12de729bcdfe93016323fb014681ddfa472f3352b5e83455991be715293211
 
 ARG GITBRANCH
 ENV GITBRANCH=${GITBRANCH:-none}
@@ -55,8 +58,6 @@ RUN apt-get update && \
     libmodsecurity-dev \
     libmodsecurity3 \
     libpcre2-dev \
-    libpcre3 \
-    libpcre3-dev \
     libssl-dev \
     libtool \
     libyajl-dev \
@@ -78,7 +79,9 @@ RUN cd /tmp \
     && rm modsecurity-nginx-v${MODSECURITY_NGINX_VERSION}.tar.gz \
     && mkdir -p /opt/modsecurity-nginx-v${MODSECURITY_NGINX_VERSION} \
     && mv modsecurity-nginx-v${MODSECURITY_NGINX_VERSION}/* /opt/modsecurity-nginx-v${MODSECURITY_NGINX_VERSION}/ \
-    && wget http://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz \
+    && sed -i 's|#include <modsecurity/modsecurity.h>|#include <stdio.h>\\n#include <modsecurity/modsecurity.h>|' /opt/modsecurity-nginx-v${MODSECURITY_NGINX_VERSION}/config \
+    && wget https://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz \
+    && echo "${NGINX_SHA512}  nginx-${NGINX_VERSION}.tar.gz" | sha512sum -c - \
     && tar -xvf nginx-${NGINX_VERSION}.tar.gz \
     && rm nginx-${NGINX_VERSION}.tar.gz \
     && mkdir -p /opt/nginx-${NGINX_VERSION} \

--- a/.docker/Dockerfile-waf-alpine
+++ b/.docker/Dockerfile-waf-alpine
@@ -4,7 +4,7 @@ FROM ubuntu:${ubuntu_version}
 LABEL maintainer="USA.gov Web Ops"
 
 ENV modsecurity_nginx_version="1.0.3"
-ENV nginx_version="1.27.2"
+ENV nginx_version="1.30.1"
 
 ARG GITBRANCH
 ENV GITBRANCH ${GITBRANCH:-none}

--- a/.docker/Dockerfile-waf-vote
+++ b/.docker/Dockerfile-waf-vote
@@ -1,5 +1,5 @@
 ARG modsecurity_nginx_version="1.0.3"
-ARG nginx_version="1.27.2"
+ARG nginx_version="1.30.1"
 ARG ubuntu_version="jammy"
 
 FROM docker.io/ubuntu:${ubuntu_version}

--- a/.docker/Dockerfile-www
+++ b/.docker/Dockerfile-www
@@ -5,6 +5,9 @@ FROM alpine:3.22 AS www
 ARG S6_VERSION
 ENV S6_VERSION=${S6_VERSION:-v2.2.0.3}
 
+ARG NGINX_VERSION=1.30.1
+ARG NGINX_SHA512=a081ed49692948ea61bada05a9bade88f9899f843c8d5a72c0d5362e812c14e1ea12de729bcdfe93016323fb014681ddfa472f3352b5e83455991be715293211
+
 ARG GITBRANCH
 ENV GITBRANCH=${GITBRANCH:-none}
 
@@ -104,17 +107,17 @@ RUN cd /tmp/ \
     && wget https://github.com/simpl/ngx_devel_kit/archive/refs/tags/v0.3.1.tar.gz \
     && tar -xzvf v0.3.1.tar.gz \
     && mv ngx_devel_kit-0.3.1 ngx_devel_kit \
-    && wget https://nginx.org/download/nginx-1.28.0.tar.gz \
-    && NGCHECKSUM="07d1ef078a73009c2aff0a5729a57f58f26512b71377715ef72cecdb249ef2ff69dd44df3d755a1de2a2721ee604e8a6cfac30a4cf8a45f0890b1746b68ee4d5 *nginx-1.28.0.tar.gz" \
-    && openssl sha512 -r nginx-1.28.0.tar.gz \
-    && if [ "$(openssl sha512 -r nginx-1.28.0.tar.gz)" = "$NGCHECKSUM" ]; then \
+    && wget https://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz \
+    && NGCHECKSUM="${NGINX_SHA512} *nginx-${NGINX_VERSION}.tar.gz" \
+    && openssl sha512 -r nginx-${NGINX_VERSION}.tar.gz \
+    && if [ "$(openssl sha512 -r nginx-${NGINX_VERSION}.tar.gz)" = "$NGCHECKSUM" ]; then \
         echo "nginx tarball checksum verification succeeded!"; \
-    else \
+      else \
         echo "nginx tarball checksum verification failed!"; \
         exit 1; \
-    fi \
-    && tar -xzvf nginx-1.28.0.tar.gz \
-    && cd nginx-1.28.0 \
+      fi \
+    && tar -xzvf nginx-${NGINX_VERSION}.tar.gz \
+    && cd nginx-${NGINX_VERSION} \
     && ./configure \
         --prefix=/var/lib/nginx \
         --sbin-path=/usr/sbin/nginx \
@@ -131,7 +134,7 @@ RUN cd /tmp/ \
     && make
 RUN rm /etc/nginx/modules/10_devel_kit.conf || true
 RUN rm /etc/nginx/modules/30_http_lua.conf || true
-RUN cd /tmp/nginx-1.28.0 \
+RUN cd /tmp/nginx-${NGINX_VERSION} \
     && make install
 
 EXPOSE 80


### PR DESCRIPTION
…ine, and waf-vote

<!--- Provide a general summary of your changes in the title above -->
## Jira Task

<!--- Provide a link to the Jira ticket -->
https://gsa-standard.atlassian-us-gov-mod.net/browse/USAGOV-2738

## Description
Updated nginx in cms, www, waf, waf-alpine, and waf-vote to 1.30.1

## Type of Changes
<!--- Put an `x` in all the boxes that apply. -->
- [ ] New Feature
- [ ] Bugfix
- [ ] Frontend (Twig, Sass, JS)
  - Add screenshot showing what it should look like
- [ ] Drupal Config (requires "drush cim")
- [ ] New Modules (requires rebuild)
- [ ] Documentation
- [ ] Infrastructure
  - [ ] CMS
  - [ ] WAF
  - [ ] WWW
  - [ ] Egress
  - [ ] Tools
  - [ ] Cron
- [ ] Other

## Testing Instructions
Deploy, log into each container, run `/usr/sbin/nginx -v`, make sure output is 1.30.1.

### Change Requirements
<!-- Checkboxes to indicate need for changes to some part of the system -->

- [ ] Requires New Documentation (Link: {})
- [ ] Requires New Config
- [ ] Requires New Content

### Validation Steps

- Test instruction 1
- Test instruction 2
- Test instruction 3

## Security Review
<!-- Checkboxes to indicate need for review -->

- [ ] Adds/updates software (including a library or Drupal module)
- [ ] Communication with external service
- [ ] Changes permissions or workflow
- [ ] Requires SSPP updates


## Reviewer Reminders

- Reviewed code changes
- Reviewed functionality
- Security review complete or not required

## Post PR Approval Instructions

Follow these steps as soon as you merge the new changes.

1. Go to the [USAGov Circle CI project](https://app.circleci.com/pipelines/github/usagov/usagov-2021).
2. Find the commit of this pull request.
3. Build and deploy the changes.
4. Update the Jira ticket by changing the ticket status to `Review in Test` and add a comment. State whether the change is already visible on [cms-dev.usa.gov](http://cms-dev.usa.gov/) and [beta-dev.usa.gov](http://beta-dev.usa.gov/), or if the deployment is still in process.
