### PR TITLE
USAGOV-2785: Autologout cookies should default to secure

### DIFF
--- a/config/sync/autologout.settings.yml
+++ b/config/sync/autologout.settings.yml
@@ -25,6 +25,6 @@ disable_buttons: false
 yes_button: ''
 no_button: ''
 whitelisted_ip_addresses: ''
-cookie_secure: false
+cookie_secure: true
 cookie_httponly: false
 console_logging: false


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
## Jira Task

<!--- Provide a link to the Jira ticket -->
https://gsa-standard.atlassian-us-gov-mod.net/browse/USAGOV-2785

## Description
<!--- Summarize the changes made in this pull request, not what it's for. -->

Change config entry for autologout secure cookies to "true"

## Type of Changes
<!--- Put an `x` in all the boxes that apply. -->
- [ ] New Feature
- [ ] Bugfix
- [ ] Frontend (Twig, Sass, JS)
  - Add screenshot showing what it should look like
- [ ] Drupal Config (requires "drush cim")
- [ ] New Modules (requires rebuild)
- [ ] Documentation
- [ ] Infrastructure
  - [x] CMS
  - [ ] WAF
  - [ ] WWW
  - [ ] Egress
  - [ ] Tools
  - [ ] Cron
- [ ] Other

## Testing Instructions

### Local
1. (Re)build CMS

### Local & Remote
2. Navigate to: /admin/config/people/autologout
3. Make sure the "Cookies Secure" checkbox is checked

### Change Requirements
<!-- Checkboxes to indicate need for changes to some part of the system -->

- [ ] Requires New Documentation (Link: {})
- [ ] Requires New Config
- [ ] Requires New Content

## Security Review
<!-- Checkboxes to indicate need for review -->

- [ ] Adds/updates software (including a library or Drupal module)
- [ ] Communication with external service
- [ ] Changes permissions or workflow
- [ ] Requires SSPP updates


## Reviewer Reminders

- Reviewed code changes
- Reviewed functionality
- Security review complete or not required

## Post PR Approval Instructions

Follow these steps as soon as you merge the new changes.

1. Go to the [USAGov Circle CI project](https://app.circleci.com/pipelines/github/usagov/usagov-2021).
4. Find the commit of this pull request.
5. Build and deploy the changes.
6. Update the Jira ticket by changing the ticket status to `Review in Test` and add a comment. State whether the change is already visible on [cms-dev.usa.gov](http://cms-dev.usa.gov/) and [beta-dev.usa.gov](http://beta-dev.usa.gov/), or if the deployment is still in process.
