### PR TITLE
USAGOV-2786: preventing "empty heading" agency-index pages

### DIFF
--- a/scripts/tome-sync.sh
+++ b/scripts/tome-sync.sh
@@ -417,14 +417,16 @@ fi
 # Detect and warn only.
 #
 
-EMPTY_HEADING_LIST=""
-EMPTY_HEADING_PROBLEM=0
+EMPTY_HEADING_LIST=$(find /var/www/html -name index.html -print0 | xargs -0 grep -HF '<h2 class="usagov-directory-letter-heading" tabindex="-1" id=""></h2>')
 
-EMPTY_HEADING_COUNT=$(find /var/www/html -name index.html -print0 | xargs -0 grep '<h2 class="usagov-directory-letter-heading" tabindex="-1" id></h2>' | wc -l)
+OLD_IFS=$IFS
+IFS=
+EMPTY_HEADING_COUNT=$(echo $EMPTY_HEADING_LIST | wc -l)
+IFS=$OLD_IFS
 
 if [ $EMPTY_HEADING_COUNT -gt 0 ]; then
   echo "WARNING: *** Empty headings found in agency index, total $EMPTY_HEADING_COUNT. List follows ***" | tee -a $TOMELOG
-  EMPTY_HEADING_LIST=$(find /var/www/html -name index.html -print0 | xargs -0 grep '<h2 class="usagov-directory-letter-heading" tabindex="-1" id></h2>')
+  # This will be one long line; that's okay.
   echo "$EMPTY_HEADING_LIST" | tee -a $TOMELOG
 fi
 

--- a/scripts/tome-sync.sh
+++ b/scripts/tome-sync.sh
@@ -413,20 +413,18 @@ fi
 ##############################################################
 
 ##############################################################
-# Empty headings in agency indes (implies also empty nav links), USAGOV-2786
-# Detect and warn only, at present!
+# Empty headings in agency index (implies also empty nav links), USAGOV-2786
+# Detect and warn only.
 #
 
 EMPTY_HEADING_LIST=""
 EMPTY_HEADING_PROBLEM=0
 
-# EMPTY_HEADING_COUNT=$(find /var/www/html -name index.html -print0 | xargs -0 grep '<h2 class="usagov-directory-letter-heading" tabindex="-1" id></h2>' | wc -l)
-EMPTY_HEADING_COUNT=$(find /var/www/html -name index.html -print0 | xargs -0 grep '<h2 class="usagov-directory-letter-heading"' | wc -l)
+EMPTY_HEADING_COUNT=$(find /var/www/html -name index.html -print0 | xargs -0 grep '<h2 class="usagov-directory-letter-heading" tabindex="-1" id></h2>' | wc -l)
 
 if [ $EMPTY_HEADING_COUNT -gt 0 ]; then
   echo "WARNING: *** Empty headings found in agency index, total $EMPTY_HEADING_COUNT. List follows ***" | tee -a $TOMELOG
-  #  EMPTY_HEADING_LIST=$(find /var/www/html -name index.html -print0 | xargs -0 grep '<h2 class="usagov-directory-letter-heading" tabindex="-1" id></h2>')
-  EMPTY_HEADING_LIST=$(find /var/www/html -name index.html -print0 | xargs -0 grep '<h2 class="usagov-directory-letter-heading"')
+  EMPTY_HEADING_LIST=$(find /var/www/html -name index.html -print0 | xargs -0 grep '<h2 class="usagov-directory-letter-heading" tabindex="-1" id></h2>')
   echo "$EMPTY_HEADING_LIST" | tee -a $TOMELOG
 fi
 

--- a/scripts/tome-sync.sh
+++ b/scripts/tome-sync.sh
@@ -412,7 +412,27 @@ fi
 # End of blog page checks (USAGOV-2667)
 ##############################################################
 
+##############################################################
+# Empty headings in agency indes (implies also empty nav links), USAGOV-2786
+# Detect and warn only, at present!
+#
 
+EMPTY_HEADING_LIST=""
+EMPTY_HEADING_PROBLEM=0
+
+# EMPTY_HEADING_COUNT=$(find /var/www/html -name index.html -print0 | xargs -0 grep '<h2 class="usagov-directory-letter-heading" tabindex="-1" id></h2>' | wc -l)
+EMPTY_HEADING_COUNT=$(find /var/www/html -name index.html -print0 | xargs -0 grep '<h2 class="usagov-directory-letter-heading"' | wc -l)
+
+if [ $EMPTY_HEADING_COUNT -gt 0 ]; then
+  echo "WARNING: *** Empty headings found in agency index, total $EMPTY_HEADING_COUNT. List follows ***" | tee -a $TOMELOG
+  #  EMPTY_HEADING_LIST=$(find /var/www/html -name index.html -print0 | xargs -0 grep '<h2 class="usagov-directory-letter-heading" tabindex="-1" id></h2>')
+  EMPTY_HEADING_LIST=$(find /var/www/html -name index.html -print0 | xargs -0 grep '<h2 class="usagov-directory-letter-heading"')
+  echo "$EMPTY_HEADING_LIST" | tee -a $TOMELOG
+fi
+
+#
+# End of Empty headings checks
+##############################################################
 
 if [ "$TOME_PUSH_NEW_CONTENT" == "1" ]; then
   echo "Pushing Content to S3: $RENDER_DIR -> $BUCKET_NAME/web/" | tee -a $TOMELOG

--- a/web/modules/custom/usa_twig_vars/usa_twig_vars.module
+++ b/web/modules/custom/usa_twig_vars/usa_twig_vars.module
@@ -228,13 +228,10 @@ function usa_twig_vars_preprocess_views_view_summary__federal_agencies(array &$v
   $current_letter = $view->getRequest()->query->get('letter') ?: 'a';
   $current_letter = mb_strtoupper($current_letter);
 
-  // We use $current_letter as part of the static key to avoid contention with
-  // other overlapping requests; see USAGOV-2786.
   $static_stash_name = usa_twig_vars_get_federal_agencies_static_name($current_letter);
   drupal_static_reset($static_stash_name);
   $shared = &drupal_static($static_stash_name);
   $shared = [];
-
   $shared['current'] = $current_letter;
 
   // Figure out next and previous letters.
@@ -256,15 +253,13 @@ function usa_twig_vars_preprocess_views_view_summary__federal_agencies(array &$v
 /**
  * Add context to the federal_agencies view.
  *
- * Allow us to show the current letter, and add links to the "next" and
+ * Enables us to show the current letter, and add links to the "next" and
  * "previous" letters.
  *
  * @param array<string, mixed> $variables
  * @param array<string, mixed> $info
  */
 function usa_twig_vars_preprocess_views_view_list__federal_agencies(array &$variables, string $hook, array $info): void {
-  // We use the requested "current_letter" as part of the static key to avoid contention with
-  // other overlapping requests; see USAGOV-2786.
   $current_letter = $variables['view']->getRequest()->query->get('letter') ?: 'a';
   $current_letter = mb_strtoupper($current_letter);
   $static_stash_name = usa_twig_vars_get_federal_agencies_static_name($current_letter);
@@ -275,9 +270,9 @@ function usa_twig_vars_preprocess_views_view_list__federal_agencies(array &$vari
 /**
  * Get a consistent name for the static variable we use to share
  * letter context between two preprocess hooks for the federal
- * agencies view. To avoid collisions between page renders,
- * we include current displayed letter and the site language,
- * in addition to a unique string based on the function that
+ * agencies view. To avoid collisions between page renders (see
+ * USAGOV-2786), we include current displayed letter and the site
+ * language, in addition to a unique string based on the function that
  * populates this variable.
  *
  * @param string $letter

--- a/web/modules/custom/usa_twig_vars/usa_twig_vars.module
+++ b/web/modules/custom/usa_twig_vars/usa_twig_vars.module
@@ -230,9 +230,9 @@ function usa_twig_vars_preprocess_views_view_summary__federal_agencies(array &$v
 
   // We use $current_letter as part of the static key to avoid contention with
   // other overlapping requests; see USAGOV-2786.
-  $our_unique_name = implode("--", ['usa_twig_vars_preprocess_view_federal_agencies', $current_letter]);
-  drupal_static_reset($our_unique_name);
-  $shared = &drupal_static($our_unique_name);
+  $static_stash_name = usa_twig_vars_get_federal_agencies_static_name($current_letter);
+  drupal_static_reset($static_stash_name);
+  $shared = &drupal_static($static_stash_name);
   $shared = [];
 
   $shared['current'] = $current_letter;
@@ -267,9 +267,27 @@ function usa_twig_vars_preprocess_views_view_list__federal_agencies(array &$vari
   // other overlapping requests; see USAGOV-2786.
   $current_letter = $variables['view']->getRequest()->query->get('letter') ?: 'a';
   $current_letter = mb_strtoupper($current_letter);
-  $our_unique_name = implode("--", ['usa_twig_vars_preprocess_view_federal_agencies', $current_letter]);
-  $alpha_context = &drupal_static($our_unique_name);
+  $static_stash_name = usa_twig_vars_get_federal_agencies_static_name($current_letter);
+  $alpha_context = &drupal_static($static_stash_name);
   $variables['alpha_context'] = $alpha_context;
+}
+
+/**
+ * Get a consistent name for the static variable we use to share
+ * letter context between two preprocess hooks for the federal
+ * agencies view. To avoid collisions between page renders,
+ * we include current displayed letter and the site language,
+ * in addition to a unique string based on the function that
+ * populates this variable.
+ *
+ * @param string $letter
+ * @return string
+ */
+function usa_twig_vars_get_federal_agencies_static_name(string $letter): string {
+  $language = \Drupal::languageManager()->getCurrentLanguage()->getId();
+  $name = implode("--",
+    ['usa_twig_vars_preprocess_view_federal_agencies', $language, $letter]);
+  return $name;
 }
 
 /**

--- a/web/modules/custom/usa_twig_vars/usa_twig_vars.module
+++ b/web/modules/custom/usa_twig_vars/usa_twig_vars.module
@@ -215,10 +215,6 @@ function usa_twig_vars_preprocess_page_title(array &$variables, string $hook): v
  * @param array<string, mixed> $info
  */
 function usa_twig_vars_preprocess_views_view_summary__federal_agencies(array &$variables, string $hook, array $info): void {
-  $our_unique_name = 'usa_twig_vars_preprocess_view_federal_agencies';
-  drupal_static_reset($our_unique_name);
-  $shared = &drupal_static($our_unique_name);
-  $shared = [];
 
   // Letters are the title_truncated in the rows of the view's "result."
   // At this point the current letter is available only via the Request object.
@@ -231,6 +227,15 @@ function usa_twig_vars_preprocess_views_view_summary__federal_agencies(array &$v
   }
   $current_letter = $view->getRequest()->query->get('letter') ?: 'a';
   $current_letter = mb_strtoupper($current_letter);
+
+  // We use $current_letter as part of the static key to avoid contention with
+  // other overlapping requests; see USAGOV-2786.
+  $our_unique_name = implode("--", ['usa_twig_vars_preprocess_view_federal_agencies', $current_letter]);
+  drupal_static_reset($our_unique_name);
+  $shared = &drupal_static($our_unique_name);
+  $shared = [];
+
+
   $shared['current'] = $current_letter;
 
   // Figure out next and previous letters.
@@ -259,7 +264,12 @@ function usa_twig_vars_preprocess_views_view_summary__federal_agencies(array &$v
  * @param array<string, mixed> $info
  */
 function usa_twig_vars_preprocess_views_view_list__federal_agencies(array &$variables, string $hook, array $info): void {
-  $alpha_context = &drupal_static('usa_twig_vars_preprocess_view_federal_agencies');
+  // We use the requested "current_letter" as part of the static key to avoid contention with
+  // other overlapping requests; see USAGOV-2786.
+  $current_letter = $variables['view']->getRequest()->query->get('letter') ?: 'a';
+  $current_letter = mb_strtoupper($current_letter);
+  $our_unique_name = implode("--", ['usa_twig_vars_preprocess_view_federal_agencies', $current_letter]);
+  $alpha_context = &drupal_static($our_unique_name);
   $variables['alpha_context'] = $alpha_context;
 }
 

--- a/web/modules/custom/usa_twig_vars/usa_twig_vars.module
+++ b/web/modules/custom/usa_twig_vars/usa_twig_vars.module
@@ -235,7 +235,6 @@ function usa_twig_vars_preprocess_views_view_summary__federal_agencies(array &$v
   $shared = &drupal_static($our_unique_name);
   $shared = [];
 
-
   $shared['current'] = $current_letter;
 
   // Figure out next and previous letters.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
## Jira Task

<!--- Provide a link to the Jira ticket -->
https://gsa-standard.atlassian-us-gov-mod.net/browse/USAGOV-2786

## Description
This is a fix for a bug I haven't been able to  reproduce. 

### The problem: 
Sometimes Agency index pages wind up on the static site with empty boxes where the letter heading (an h2) and the "next" and "previous" letters should be. There are some screenshots attached to the Jira ticket. This is intermittent. 

### My theory about why this happens: 
I think the rendering of two or more pages can overlap when Tome is generating the static site pages. I think this mainly because it would explain the problem. I am fuzzy on: 
 - whether pages might be rendered in multiple threads in the same process
 - whether page rendering might be interleaved in some other way 

Agency index pages use two "view" blocks. One contains all the letters that are present as pages in the view. The other contains the entries for agencies that should be displayed on this page. The letter heading and next/previous navigation  are rendered with the second block, but the information to calculate next and previous is only present in the first block. 

So, we have a preprocess hook for each of these blocks. The first figures out what the current, next, and previous letters are and stashes them in a `drupal_static` variable; the second accesses that variable. Crucially, the first sets that variable to an empty array before populating it. If rendering of pages overlaps, it would be possible for a page to pick up that variable while it is an empty array. 

### How this PR addresses the problem

1. Minor modifications to `usa_twig_vars.module` add the "current letter" and language code to the string by which the static variable is accessed. This will prevent overlapping requests (for different lettered pages) from accessing each other's data. 
2. Adds a clause to `tome-sync.sh` that greps for the pattern of an empty heading in an agency index page and emits a warning if that pattern is found. I plan to set up an alert that will trigger on this warning so I can investigate further when it happens. 

Since I haven't figured out how to reproduce this problem, I modified the `tome-sync.sh` change locally to warn on any letter heading, so I could show what that output would look like. The attached `example-warnings.txt` shows that. 

[example-warnings.txt](https://github.com/user-attachments/files/31815154/example-warnings.txt)


## Type of Changes
<!--- Put an `x` in all the boxes that apply. -->
- [ ] New Feature
- [x] Bugfix
- [ ] Frontend (Twig, Sass, JS)
  - Add screenshot showing what it should look like
- [ ] Drupal Config (requires "drush cim")
- [ ] New Modules (requires rebuild)
- [ ] Documentation
- [ ] Infrastructure
  - [ ] CMS
  - [ ] WAF
  - [ ] WWW
  - [ ] Egress
  - [ ] Tools
  - [ ] Cron
- [ ] Other

## Testing Instructions
<!-- This instructions are different from “testing instructions” in Jira – those are typically for Content/UX stakeholders -->
<!-- Not “see Jira” – if they are really the same, copy and paste. -->

### Change Requirements
<!-- Checkboxes to indicate need for changes to some part of the system -->

- [ ] Requires New Documentation (Link: {})
- [ ] Requires New Config
- [ ] Requires New Content

### Validation Steps

All I know how to reliably test is that the agency indexes (both English and Spanish) generate correctly. I would recommend deploying this branch to dev and letting static site generation run, then reviewing the result. 

## Security Review
<!-- Checkboxes to indicate need for review -->

- [ ] Adds/updates software (including a library or Drupal module)
- [ ] Communication with external service
- [ ] Changes permissions or workflow
- [ ] Requires SSPP updates


## Reviewer Reminders

- Reviewed code changes
- Reviewed functionality
- Security review complete or not required

## Post PR Approval Instructions

Follow these steps as soon as you merge the new changes.

1. Go to the [USAGov Circle CI project](https://app.circleci.com/pipelines/github/usagov/usagov-2021).
4. Find the commit of this pull request.
5. Build and deploy the changes.
6. Update the Jira ticket by changing the ticket status to `Review in Test` and add a comment. State whether the change is already visible on [cms-dev.usa.gov](http://cms-dev.usa.gov/) and [beta-dev.usa.gov](http://beta-dev.usa.gov/), or if the deployment is still in process.
